### PR TITLE
feat(lookup-app): custom styling, and clipboard integration

### DIFF
--- a/docs/anilist_tracking.md
+++ b/docs/anilist_tracking.md
@@ -1,18 +1,18 @@
 # AniList Episode Tracking
 
-Integrates AniList with Yomipv, enabling automatic episode progress updates.
+Integrates AniList with Yomipv, enabling automatic episode progress updates
 
 ## Setup
-1. Launch any video in MPV.
-2. Press `Ctrl+A` (or the custom key defined in `key_anilist_auth` within `yomipv.conf`).
-3. Your browser will open the AniList authorization page, and a terminal window will pop up at the same time.
-4. Click **Approve** in the browser.
-5. Copy the full URL from the address bar.
-6. Paste it into the terminal and press Enter.
-7. The token will be extracted, saved to `yomipv.conf`, and tracking will be enabled.
-8. Restart MPV so the tracker starts working.
+1. Launch any video in MPV
+2. Press `Ctrl+A` (or the custom key defined in `key_anilist_auth` within `yomipv.conf`)
+3. Your browser will open the AniList authorization page, and a terminal window will pop up at the same time
+4. Click **Approve** in the browser
+5. Copy the full URL from the address bar
+6. Paste it into the terminal and press Enter
+7. The token will be extracted, saved to `yomipv.conf`, and tracking will be enabled
+8. Restart MPV so the tracker starts working
 
 ## Features
-- **Automatic Tracking:** Updates your progress once playback passes `anilist_update_thresh_percent` (default: 80%).
-- **Episode Number Conversion:** Automatically converts absolute episode numbers (*Re Zero kara Hajimeru Isekai Seikatsu - 67*) into AniList’s seasonal format (*Season 4 Episode 1*). No manual mapping needed.
-- **Configurable Notifications:** Toggle on-screen success alerts via the `anilist_show_notifications` setting. Internal checks prevent API spam when seeking through the timeline.
+- **Automatic Tracking:** Updates your progress once playback passes `anilist_update_thresh_percent` (default: 80%)
+- **Episode Number Conversion:** Automatically converts absolute episode numbers (*Re Zero kara Hajimeru Isekai Seikatsu - 67*) into AniList’s seasonal format (*Season 4 Episode 1*). No manual mapping needed
+- **Configurable Notifications:** Toggle on-screen success alerts via the `anilist_show_notifications` setting. Internal checks prevent API spam when seeking through the timeline

--- a/docs/lookup-app.md
+++ b/docs/lookup-app.md
@@ -13,6 +13,7 @@ The lookup window appears when you search for a word. Depending on your configur
 Right-click anywhere inside the lookup window to open the **Context Menu**
 
 ### Context Menu
+- **Copy**: Copies the currently selected text to the clipboard (only enabled when text is selected)
 - **Inspect Element**: Opens the developer tools (Inspector) for the lookup window.
 - **Refresh CSS**: Instantly reloads your custom styles from `yomipv.css` (see [Custom Styling](#custom-styling))
 
@@ -38,6 +39,7 @@ You can also start a new search directly from the lookup window header:
 
 ### Selecting Text
 - Just like in Yomitan’s popup, you can select any text inside definitions to populate your Selection Text field in Anki when `popup-selection-text` is being used
+- **Copy to Clipboard**: Press `Ctrl+c` while text is selected inside the lookup window to copy it to your clipboard. This also clears the current selection
 
 ### Choosing a Specific Dictionary
 - **Click the Dictionary Title** to select that specific dictionary to populate the Definition field in Anki if `selected-dict` is being used

--- a/docs/lookup-app.md
+++ b/docs/lookup-app.md
@@ -1,46 +1,70 @@
 ## Lookup App
 
-The Lookup App is an interactive overlay that displays dictionary definitions, pitch accents, and frequencies for words you select in MPV directly, All data is taken from your installed dictionaries in Yomitan.
+The Lookup App is an interactive overlay that displays dictionary definitions, pitch accents, and frequencies for words you select in MPV directly, All data is taken from your installed dictionaries in Yomitan
 
 ## How it Works
 
-The lookup window appears when you search for a word. Depending on your configuration, this can happen automatically or manually.
+The lookup window appears when you search for a word. Depending on your configuration, this can happen automatically or manually
 
-- **Automatic Lookup**: Can be disabled in your settings (`selector_lookup_on_hover`).
-  - `selector_lookup_on_navigation` can also be enabled to trigger a lookup when navigating through the selector using Left/Right arrow keys.
-- **Manual Lookup**: Press `Ctrl+c` (default) while hovering over a word in the selector.
+- **Automatic Lookup**: Can be disabled in your settings (`selector_lookup_on_hover`)
+  - `selector_lookup_on_navigation` can also be enabled to trigger a lookup when navigating through the selector using Left/Right arrow keys
+- **Manual Lookup**: Press `Ctrl+c` (default) while hovering over a word in the selector
 
-The window stays on top of MPV until the selector is confirmed or cancelled. 
-Right-click to lock the window, preventing accidental changes when the cursor moves over another word in the selector.
+Right-click anywhere inside the lookup window to open the **Context Menu**
+
+### Context Menu
+- **Inspect Element**: Opens the developer tools (Inspector) for the lookup window.
+- **Refresh CSS**: Instantly reloads your custom styles from `yomipv.css` (see [Custom Styling](#custom-styling))
+
+The window stays on top of MPV until the selector is confirmed or cancelled
+You can lock the window to prevent accidental changes when the cursor moves over another word in the selector by right-clicking the selected word in the selector
 
 ### Result Sorting
-By default, the Lookup prioritizes the **longest match** first. This ensures that conjugated forms and compound words are shown before shorter matches (this mimics Yomitan's default behavior).
+By default, the Lookup prioritizes the **longest match** first. This ensures that conjugated forms and compound words are shown before shorter matches (this mimics Yomitan's default behavior)
 
-If you prefer entries that contain Kanji to be prioritized over match length, you can set `prioritize_kanji_match` to `yes` in your `yomipv.conf` file.
+If you prefer entries that contain Kanji to be prioritized over match length, you can set `prioritize_kanji_match` to `yes` in your `yomipv.conf` file
 
 ### Navigating Multiple Results
-If a word has multiple entries, you will see a counter (like `1 / 3`) at the top.
-- Click the Left/Right buttons of the lookup window to cycle through different entries.
+If a word has multiple entries, you will see a counter (like `1 / 3`) at the top
+- Click the Left/Right buttons of the lookup window to cycle through different entries
 
 ### Sub-word Lookups
-With `selector_lookup_on_hover` (enabled by default) and `selector_lookup_on_navigation`, you can open the lookup for sub-words directly from the subtitle.
+With `selector_lookup_on_hover` (enabled by default) and `selector_lookup_on_navigation`, you can open the lookup for sub-words directly from the subtitle
 You can also start a new search directly from the lookup window header:
-- **Click any mora** in the headword to begin a new lookup from that position.
-- **Right-click the header** to go back to the previous word you were looking at.
+- **Click any mora** in the headword to begin a new lookup from that position
+- **Right-click the header** to go back to the previous word you were looking at
 
 ## Working with Definitions
 
 ### Selecting Text
-- Just like in Yomitan’s popup, you can select any text inside definitions to populate your Selection Text field in Anki when `popup-selection-text` is being used.
+- Just like in Yomitan’s popup, you can select any text inside definitions to populate your Selection Text field in Anki when `popup-selection-text` is being used
 
 ### Choosing a Specific Dictionary
-- **Click the Dictionary Title** to select that specific dictionary to populate the Definition field in Anki if `selected-dict` is being used.
-- When you select a dictionary, `popup-selection-text` is ignored, and you can select text from the definition to be highlighted.
+- **Click the Dictionary Title** to select that specific dictionary to populate the Definition field in Anki if `selected-dict` is being used
+- When you select a dictionary, `popup-selection-text` is ignored, and you can select text from the definition to be highlighted
 
 ## Frequencies
-- By default the lookup app will show the frequencies of the word you are looking up.
-- You can disable this by setting `lookup_show_frequencies` to `no` in your `yomipv.conf` file.
+- By default the lookup app will show the frequencies of the word you are looking up
+- You can disable this by setting `lookup_show_frequencies` to `no` in your `yomipv.conf` file
 
 ## Pitch Accents
-- By default, the Lookup App shows the pitch accents (if available) of the word you are looking up and also colors the word according to its pitch accent.
-- You can disable this by setting `lookup_show_pitch_accents` to `no` in your `yomipv.conf` file.
+- By default, the Lookup App shows the pitch accents (if available) of the word you are looking up and also colors the word according to its pitch accent
+- You can disable this by setting `lookup_show_pitch_accents` to `no` in your `yomipv.conf` file
+
+## Custom Styling
+
+You can fully customize the appearance of the lookup window using a local CSS file
+
+1. Open the `yomipv.css` file inside your `script-opts` folder
+2. Add your custom CSS variables or overrides to this file
+3. Your changes are automatically detected. Use the **Refresh CSS** option in the [Context Menu](#context-menu) to see your styling changes live without restarting MPV
+
+The `yomipv-updater` is designed to preserve this file, ensuring your personal theme isn't lost during project updates
+
+## Developer Tools
+
+- Right-click anywhere in the lookup window and select **Inspect Element**
+- This opens a detached Electron DevTools window focused on the **Elements** panel
+- While the Inspector is open, the lookup window becomes **movable**, allowing you to reposition it anywhere on your screen
+- Closing the Inspector will snap the lookup window back to its original position
+- A tray icon appears while the Inspector is active, allowing you to restore the window if it's minimized

--- a/script-opts/yomipv.css
+++ b/script-opts/yomipv.css
@@ -1,0 +1,4 @@
+/* 
+ * Custom styles for lookup
+ * Right-click in lookup app for "Refresh CSS" to apply changes live
+ */

--- a/scripts/yomipv/export/handler.lua
+++ b/scripts/yomipv/export/handler.lua
@@ -967,6 +967,22 @@ function Handler:build_selector_style(update_range_fn, was_paused, tokens)
 			end
 		end,
 		on_lookup = function(data)
+			if self.last_selection then
+				mp.command_native_async({
+					name = "subprocess",
+					playback_only = false,
+					args = {
+						Platform.get_curl_cmd(),
+						"-s",
+						"-X",
+						"POST",
+						"--connect-timeout",
+						"1",
+						"http://127.0.0.1:19634/copy",
+					},
+				}, function() end)
+				return
+			end
 			if self.pending_lookup_term == data.term and self.pending_lookup_reading == data.reading then
 				return
 			end

--- a/scripts/yomipv/export/handler.lua
+++ b/scripts/yomipv/export/handler.lua
@@ -975,6 +975,12 @@ function Handler:build_selector_style(update_range_fn, was_paused, tokens)
 			self.active_entry_reading = nil
 			self.pending_lookup_term = data.term
 			self.pending_lookup_reading = data.reading
+
+			local custom_css = mp.command_native({ "expand-path", "~~/script-opts/yomipv.css" })
+			if require("mp.utils").file_info(custom_css) == nil then
+				custom_css = nil
+			end
+
 			local data_to_send = {
 				term = data.term,
 				reading = data.reading,
@@ -983,6 +989,7 @@ function Handler:build_selector_style(update_range_fn, was_paused, tokens)
 				prioritizeKanjiMatch = self.config.prioritize_kanji_match,
 				prioritizeHiraganaMatch = self.config.prioritize_hiragana_match,
 				theme = self.config.lookup_theme,
+				customCss = custom_css,
 			}
 			local json_body = require("mp.utils").format_json(data_to_send)
 			Curl.post("http://127.0.0.1:19634", json_body, function() end)

--- a/scripts/yomipv/lookup-app/main.js
+++ b/scripts/yomipv/lookup-app/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, Tray, Menu, nativeImage } = require('electron');
 const path = require('path');
 const http = require('http');
 const net = require('net');
@@ -166,6 +166,152 @@ app.on('window-all-closed', () => {
 
 ipcMain.on('hide-window', () => {
   mainWindow.hide();
+});
+
+ipcMain.on('move-window', (event, { dx, dy }) => {
+  if (!mainWindow) return;
+  const [x, y] = mainWindow.getPosition();
+  mainWindow.setPosition(x + dx, y + dy);
+});
+
+let devToolsWin = null;
+
+let inspectorTray = null;
+
+function createInspectorTray() {
+  const iconPath = path.join(__dirname, 'build', 'lookup-app.png');
+  const icon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 });
+  inspectorTray = new Tray(icon);
+  inspectorTray.setToolTip('Yomipv Inspector');
+
+  const updateMenu = () => {
+    const menu = Menu.buildFromTemplate([
+      {
+        label: 'Show Inspector',
+        click: () => {
+          if (devToolsWin) {
+            if (devToolsWin.isMinimized()) devToolsWin.restore();
+            devToolsWin.show();
+            devToolsWin.focus();
+          }
+        }
+      },
+      {
+        label: 'Close Inspector',
+        click: () => {
+          if (devToolsWin && !devToolsWin.isDestroyed()) devToolsWin.close();
+        }
+      }
+    ]);
+    inspectorTray.setContextMenu(menu);
+  };
+
+  updateMenu();
+  inspectorTray.on('click', () => {
+    if (devToolsWin) {
+      if (devToolsWin.isMinimized()) devToolsWin.restore();
+      devToolsWin.show();
+      devToolsWin.focus();
+    }
+  });
+}
+
+function destroyInspectorTray() {
+  if (inspectorTray) {
+    inspectorTray.destroy();
+    inspectorTray = null;
+  }
+}
+
+function openInspector() {
+  if (!mainWindow) return;
+  
+  if (devToolsWin && !devToolsWin.isDestroyed()) {
+    if (devToolsWin.isMinimized()) devToolsWin.restore();
+    devToolsWin.show();
+    devToolsWin.focus();
+    return;
+  }
+
+  devToolsWin = new BrowserWindow({
+    width: 800,
+    height: 600,
+    title: "Yomipv Inspector",
+    alwaysOnTop: true,
+    skipTaskbar: false,
+    autoHideMenuBar: true
+  });
+
+  devToolsWin.setAlwaysOnTop(true, 'screen-saver', 2);
+
+  mainWindow.webContents.setDevToolsWebContents(devToolsWin.webContents);
+  mainWindow.webContents.openDevTools({ mode: 'detach' });
+
+  devToolsWin.webContents.once('dom-ready', () => {
+    devToolsWin.webContents.executeJavaScript(
+      "UI.inspectorView.showPanel('elements')"
+    ).catch(() => {});
+  });
+
+  // Enable manual window repositioning during inspection
+  mainWindow.setMovable(true);
+  mainWindow.setFocusable(true);
+  mainWindow.webContents.send('inspector-mode', true);
+
+  const savedPosition = mainWindow.getPosition();
+
+  createInspectorTray();
+
+  const onInspectorClose = () => {
+    destroyInspectorTray();
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.setPosition(savedPosition[0], savedPosition[1]);
+      mainWindow.setMovable(false);
+      mainWindow.setFocusable(false);
+      mainWindow.webContents.send('inspector-mode', false);
+    }
+  };
+
+  mainWindow.webContents.once('devtools-closed', () => {
+    onInspectorClose();
+    if (devToolsWin && !devToolsWin.isDestroyed()) {
+      devToolsWin.close();
+    }
+    devToolsWin = null;
+  });
+
+  devToolsWin.on('closed', () => {
+    onInspectorClose();
+    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.webContents.isDevToolsOpened()) {
+      mainWindow.webContents.closeDevTools();
+    }
+    devToolsWin = null;
+  });
+}
+
+ipcMain.on('open-inspector', () => {
+  openInspector();
+});
+
+ipcMain.on('show-context-menu', (event) => {
+  const template = [
+    {
+      label: 'Inspect Element',
+      click: () => {
+        openInspector();
+      }
+    },
+    {
+      label: 'Refresh CSS',
+      click: () => {
+        if (mainWindow) {
+          mainWindow.webContents.send('refresh-css');
+        }
+      }
+    }
+  ];
+  const menu = Menu.buildFromTemplate(template);
+  menu.popup(BrowserWindow.fromWebContents(event.sender));
 });
 
 ipcMain.on('sync-selection', (event, text) => {

--- a/scripts/yomipv/lookup-app/main.js
+++ b/scripts/yomipv/lookup-app/main.js
@@ -97,6 +97,15 @@ app.whenReady().then(() => {
           return;
         }
 
+        if (req.url === '/copy') {
+          console.log('[IPC] Copy signal received');
+          res.end('ok');
+          if (mainWindow) {
+            mainWindow.webContents.send('copy-selection');
+          }
+          return;
+        }
+
         if (req.url === '/hide') {
           console.log('[IPC] Hide signal received, requesting renderer clear');
           res.end('hiding');
@@ -293,8 +302,18 @@ ipcMain.on('open-inspector', () => {
   openInspector();
 });
 
-ipcMain.on('show-context-menu', (event) => {
+ipcMain.on('show-context-menu', (event, hasSelection) => {
   const template = [
+    {
+      label: 'Copy',
+      enabled: hasSelection,
+      click: () => {
+        if (mainWindow) {
+          mainWindow.webContents.send('copy-selection');
+        }
+      }
+    },
+    { type: 'separator' },
     {
       label: 'Inspect Element',
       click: () => {

--- a/scripts/yomipv/lookup-app/renderer.js
+++ b/scripts/yomipv/lookup-app/renderer.js
@@ -618,8 +618,86 @@ ipcRenderer.on('lookup-term', async (event, data) => {
     document.body.classList.remove('light-theme');
   }
 
+  if (data.customCss) {
+    let customLink = document.getElementById('custom-css');
+    if (!customLink) {
+      customLink = document.createElement('link');
+      customLink.id = 'custom-css';
+      customLink.rel = 'stylesheet';
+      document.head.appendChild(customLink);
+    }
+    let cssUrl = data.customCss;
+    if (!cssUrl.startsWith('http') && !cssUrl.startsWith('file://')) {
+      cssUrl = 'file:///' + cssUrl.replace(/\\/g, '/');
+    }
+    if (customLink.href !== cssUrl) {
+      customLink.href = cssUrl;
+    }
+  } else {
+    const customLink = document.getElementById('custom-css');
+    if (customLink) customLink.remove();
+  }
+
   lookupHistory = [];
   performLookup(data.term, data.showFrequencies, data.showPitchAccents, false, data.prioritizeKanjiMatch, data.prioritizeHiraganaMatch);
+});
+
+document.body.addEventListener('contextmenu', (e) => {
+  ipcRenderer.send('show-context-menu');
+});
+
+ipcRenderer.on('refresh-css', () => {
+  const customLink = document.getElementById('custom-css');
+  if (customLink) {
+    const url = new URL(customLink.href);
+    url.searchParams.set('t', Date.now().toString());
+    customLink.href = url.toString();
+    console.log('[UI] CSS refreshed:', customLink.href);
+  }
+});
+
+ipcRenderer.on('inspector-mode', (event, active) => {
+  const container = document.getElementById('lookup-container');
+  if (active) {
+    container.style.cursor = 'move';
+
+    let dragging = false;
+    let startX = 0;
+    let startY = 0;
+
+    container._onMouseDown = (e) => {
+      if (e.target.closest('button, a, input, select')) return;
+      dragging = true;
+      startX = e.screenX;
+      startY = e.screenY;
+      e.preventDefault();
+    };
+
+    container._onMouseMove = (e) => {
+      if (!dragging) return;
+      const dx = e.screenX - startX;
+      const dy = e.screenY - startY;
+      startX = e.screenX;
+      startY = e.screenY;
+      ipcRenderer.send('move-window', { dx, dy });
+    };
+
+    container._onMouseUp = () => { dragging = false; };
+
+    container.addEventListener('mousedown', container._onMouseDown);
+    window.addEventListener('mousemove', container._onMouseMove);
+    window.addEventListener('mouseup', container._onMouseUp);
+  } else {
+    container.style.cursor = '';
+    if (container._onMouseDown) {
+      container.removeEventListener('mousedown', container._onMouseDown);
+      window.removeEventListener('mousemove', container._onMouseMove);
+      window.removeEventListener('mouseup', container._onMouseUp);
+      container._onMouseDown = null;
+      container._onMouseMove = null;
+      container._onMouseUp = null;
+    }
+  }
 });
 
 ipcRenderer.on('window-hide-request', () => {

--- a/scripts/yomipv/lookup-app/renderer.js
+++ b/scripts/yomipv/lookup-app/renderer.js
@@ -9,6 +9,43 @@ const entryCounter = document.getElementById('entry-counter');
 let isWindowVisible = false;
 let isPerformingLookup = false;
 
+const clearSelection = () => {
+  window.getSelection().removeAllRanges();
+  document.querySelectorAll('.highlight').forEach(el => {
+    const parent = el.parentNode;
+    while (el.firstChild) {
+      parent.insertBefore(el.firstChild, el);
+    }
+    parent.removeChild(el);
+  });
+  ipcRenderer.send('sync-selection', '');
+
+  // If a dictionary was selected, refresh its state in MPV without the highlights
+  const selectedTitle = glossaryEl.querySelector('[data-dictionary] > .selected');
+  const targetDict = selectedTitle?.parentElement;
+  if (targetDict) {
+    sendSelectedDict(targetDict);
+  }
+};
+
+const syncSelection = () => {
+  const selectionObj = window.getSelection();
+  if (selectionObj.rangeCount === 0 || selectionObj.isCollapsed) return;
+
+  const range = selectionObj.getRangeAt(0);
+  if (!glossaryEl.contains(range.commonAncestorContainer)) return;
+
+  let selection = selectionObj.toString().trim();
+  if (!selection) return;
+
+  selection = selection.replace(/\r?\n/g, '<br>');
+
+  const selectedTitle = glossaryEl.querySelector('[data-dictionary] > .selected');
+  const formattedSelection = selectedTitle ? `<b>${selection}</b>` : selection;
+
+  ipcRenderer.send('sync-selection', formattedSelection);
+};
+
 let allEntries = [];
 let currentEntryIndex = 0;
 let currentShowFrequencies = false;
@@ -256,6 +293,7 @@ const renderEntry = (index, rawEntries, showFrequencies, showPitchAccents) => {
       });
       titleEl.classList.add('selected');
       sendSelectedDict(el);
+      syncSelection();
     });
   });
 
@@ -285,6 +323,12 @@ const sendSelectedDict = (el) => {
     link.style.removeProperty('cursor');
     if (!link.style.cssText) link.removeAttribute('style');
   });
+
+  // Strip highlight class from the export HTML so Anki gets clean <b> tags
+  exportEl.querySelectorAll('.highlight').forEach(el => {
+    el.removeAttribute('class');
+  });
+
   const exportTitle = exportEl.firstElementChild;
   if (exportTitle) {
     if (exportTitle.dataset.originalTitle) {
@@ -317,6 +361,8 @@ const sendSelectedDict = (el) => {
 const performLookup = async (term, showFrequencies, showPitchAccents, isBack = false, prioritizeKanjiMatch, prioritizeHiraganaMatch) => {
   console.log('[UI] Performing lookup for:', term);
   
+  clearSelection();
+
   const container = document.getElementById('lookup-container');
   const isVisible = container.classList.contains('visible');
 
@@ -642,8 +688,17 @@ ipcRenderer.on('lookup-term', async (event, data) => {
   performLookup(data.term, data.showFrequencies, data.showPitchAccents, false, data.prioritizeKanjiMatch, data.prioritizeHiraganaMatch);
 });
 
+ipcRenderer.on('copy-selection', () => {
+  const selection = window.getSelection().toString();
+  if (selection) {
+    require('electron').clipboard.writeText(selection);
+  }
+  clearSelection();
+});
+
 document.body.addEventListener('contextmenu', (e) => {
-  ipcRenderer.send('show-context-menu');
+  const hasSelection = window.getSelection().toString().length > 0;
+  ipcRenderer.send('show-context-menu', hasSelection);
 });
 
 ipcRenderer.on('refresh-css', () => {
@@ -739,16 +794,7 @@ let selectionTimeout;
 document.addEventListener('selectionchange', () => {
   clearTimeout(selectionTimeout);
   selectionTimeout = setTimeout(() => {
-    const selectionObj = window.getSelection();
-    if (selectionObj.rangeCount === 0 || selectionObj.isCollapsed) return;
-
-    const range = selectionObj.getRangeAt(0);
-    if (!glossaryEl.contains(range.commonAncestorContainer)) return;
-
-    let selection = selectionObj.toString().trim();
-    if (!selection) return;
-    selection = selection.replace(/\r?\n/g, '<br>');
-    ipcRenderer.send('sync-selection', selection);
+    syncSelection();
   }, 200);
 });
 
@@ -777,13 +823,13 @@ document.addEventListener('mouseup', () => {
   const hasBlocks = contents.querySelector('div, p, li, ol, ul');
 
   if (!hasBlocks) {
-    const span = document.createElement('span');
-    span.className = 'highlight';
+    const b = document.createElement('b');
+    b.className = 'highlight';
     try {
-      range.surroundContents(span);
+      range.surroundContents(b);
     } catch (e) {
-      span.appendChild(range.extractContents());
-      range.insertNode(span);
+      b.appendChild(range.extractContents());
+      range.insertNode(b);
     }
   }
 

--- a/yomipv-updater.ps1
+++ b/yomipv-updater.ps1
@@ -115,6 +115,22 @@ function Merge-Config ($OldConfig) {
     }
 }
 
+function Backup-Css {
+    $css_path = Join-Path $PSScriptRoot "script-opts\yomipv.css"
+    if (Test-Path $css_path) {
+        Copy-Item -Path $css_path -Destination "$css_path.tmp_backup" -Force
+        return $true
+    }
+    return $false
+}
+
+function Restore-Css ($has_css) {
+    if ($has_css) {
+        $css_path = Join-Path $PSScriptRoot "script-opts\yomipv.css"
+        Move-Item -Path "$css_path.tmp_backup" -Destination $css_path -Force
+    }
+}
+
 function Update-Dependencies {
     $app_dir = Join-Path $PSScriptRoot "scripts\yomipv\lookup-app"
     if (Test-Path (Join-Path $app_dir "package.json")) {
@@ -238,7 +254,9 @@ function Update-Yomipv {
         
         Write-Host "New updates available. Pulling..." -ForegroundColor Green
         $oldConfig = Get-Config
+        $hasCss = Backup-Css
         git pull origin main
+        Restore-Css $hasCss
         Merge-Config $oldConfig
         return $true
     }
@@ -263,6 +281,7 @@ function Update-Yomipv {
         Install-7z
         
         $oldConfig = Get-Config
+        $hasCss = Backup-Css
         
         $extract_dir = Join-Path $env:TEMP "yomipv-extract"
         if (Test-Path $extract_dir) { Remove-Item $extract_dir -Recurse -Force }
@@ -274,6 +293,7 @@ function Update-Yomipv {
         if ($source_folder) {
             Write-Host "Applying source changes..." -ForegroundColor Green
             Copy-Item -Path (Join-Path $source_folder.FullName "*") -Destination $PSScriptRoot -Recurse -Force
+            Restore-Css $hasCss
             Merge-Config $oldConfig
         }
         
@@ -329,11 +349,13 @@ function Update-Yomipv {
         if (-not $zip_url) { throw "Could not find a valid download URL." }
         
         $oldConfig = Get-Config
+        $hasCss = Backup-Css
         
         $temp_zip = Join-Path $env:TEMP "yomipv-update.zip"
         Receive-Archive $temp_zip $zip_url
         Install-7z
         Expand-YomipvArchive $temp_zip $PSScriptRoot
+        Restore-Css $hasCss
         Merge-Config $oldConfig
         
         Remove-Item $temp_zip -ErrorAction Ignore

--- a/yomipv-updater.sh
+++ b/yomipv-updater.sh
@@ -95,6 +95,24 @@ merge_config() {
     fi
 }
 
+backup_css() {
+    local css_file="$SCRIPT_DIR/script-opts/yomipv.css"
+    if [ -f "$css_file" ]; then
+        cp "$css_file" "${css_file}.tmp_backup"
+        echo 1
+    else
+        echo 0
+    fi
+}
+
+restore_css() {
+    local has_css="$1"
+    local css_file="$SCRIPT_DIR/script-opts/yomipv.css"
+    if [ "$has_css" = "1" ] && [ -f "${css_file}.tmp_backup" ]; then
+        mv "${css_file}.tmp_backup" "$css_file"
+    fi
+}
+
 update_from_source() {
     echo -e "${CYAN}Updating from source (main branch)...${NC}"
     local zip_url="https://github.com/$REPO/archive/refs/heads/main.zip"
@@ -103,6 +121,7 @@ update_from_source() {
     curl -L -A "$USER_AGENT" -o "$temp_zip" "$zip_url"
     
     local old_conf=$(get_config)
+    local has_css=$(backup_css)
     local extract_dir="/tmp/yomipv-extract"
     rm -rf "$extract_dir" && mkdir -p "$extract_dir"
     
@@ -114,8 +133,9 @@ update_from_source() {
         local mpv_instances=$(get_mpv_instances)
         stop_yomipv_processes
         
-        # Copy everything except .git
+        # Copy source files excluding git metadata
         cp -r "$source_folder"* "$SCRIPT_DIR/"
+        restore_css "$has_css"
         merge_config "$old_conf"
         restart_mpv_instances "$mpv_instances"
     fi
@@ -139,10 +159,12 @@ if [ -d "$SCRIPT_DIR/.git" ]; then
     
     echo -e "${GREEN}New updates available. Pulling...${NC}"
     local old_conf=$(get_config)
+    local has_css=$(backup_css)
     local mpv_instances=$(get_mpv_instances)
     stop_yomipv_processes
     
     git pull origin main
+    restore_css "$has_css"
     merge_config "$old_conf"
     restart_mpv_instances "$mpv_instances"
     
@@ -224,11 +246,13 @@ TEMP_ZIP="/tmp/yomipv-update.zip"
 curl -L -A "$USER_AGENT" -o "$TEMP_ZIP" "$ZIP_URL"
 
 old_conf=$(get_config)
+has_css=$(backup_css)
 mpv_instances=$(get_mpv_instances)
 stop_yomipv_processes
 
 echo -e "${GREEN}Extracting update...${NC}"
 unzip -o -q "$TEMP_ZIP" -d "$SCRIPT_DIR"
+restore_css "$has_css"
 merge_config "$old_conf"
 restart_mpv_instances "$mpv_instances"
 


### PR DESCRIPTION
Add support for custom styling, clipboard copying, and developer tools in the lookup app via context menu

---

**Clipboard and Context Menu**

* Add native context menu to the lookup window
* Support copying selected text via **Ctrl+C** and context menu

**Custom Styling**

* Allow custom css via `yomipv.css`
* Preserve user styles during updates
* Add **Refresh CSS** option in the context menu to apply changes without restarting MPV

**Dev Tools (Inspector Mode)**

* Add “Inspect Element” in context menu to open DevTools
* Make lookup window movable while DevTools is open
* Restore original position when DevTools is closed
* Add tray icon when DevTools is minimized

**Anki Formatting**

* Replace `<span class="highlight">` with `<b>` for selection highlights to improve compatibility across note types
