### PR TITLE
feat: add settings UI + profile system

### DIFF
--- a/script-opts/yomipv.conf
+++ b/script-opts/yomipv.conf
@@ -147,6 +147,7 @@ note_tag=アニメ
 # --- Selector settings ---
 
 # Behavior
+pre_tokenize=yes
 selector_show_history=yes
 selector_hide_ui=yes
 selector_navigation_delay=0.05
@@ -160,7 +161,6 @@ selector_colorize_underline=yes
 
 # Lookup
 # See https://github.com/BrenoAqua/Yomipv/blob/main/docs/lookup-app.md for more info
-pre_tokenize=yes
 selector_lookup_on_hover=yes
 selector_lookup_on_navigation=no
 selector_lookup_delay=0.1
@@ -221,9 +221,6 @@ key_set_timing_end=w
 key_clear_timings=e
 key_build_ankidb=B
 key_toggle_picture_animated=g
-
-# Misc
-lookup_app_path=lookup-app
 
 # --- History settings ---
 
@@ -300,3 +297,12 @@ key_update=U
 
 # Show OSD messages
 osd_messages=yes
+
+# --- Settings ---
+
+# Active profile
+current_profile=default
+
+# Keybindings
+key_open_settings=Ctrl+i
+key_cycle_profile=Ctrl+p

--- a/scripts/yomipv/api/anilist_tracker.lua
+++ b/scripts/yomipv/api/anilist_tracker.lua
@@ -86,8 +86,8 @@ function AnilistTracker:trigger_update()
 	end
 
 	if not episode_num then
-		msg.warn("AniList Tracker: Could not extract episode number from file (" .. name .. ").")
-		return
+		msg.info("AniList Tracker: No episode number found, defaulting to 1 (likely a movie/special).")
+		episode_num = 1
 	end
 
 	self.anilist:check_and_update(name, season_num, episode_num, function(success, err)

--- a/scripts/yomipv/api/ankiconnect.lua
+++ b/scripts/yomipv/api/ankiconnect.lua
@@ -11,7 +11,6 @@ function AnkiConnect.new(config, curl)
 	local obj = {
 		config = config,
 		curl = curl,
-		url = "http://" .. config.ankiconnect_url,
 		media_dir_path = nil,
 		_pending_media_path_callbacks = nil,
 	}
@@ -20,9 +19,14 @@ function AnkiConnect.new(config, curl)
 	return obj
 end
 
-function AnkiConnect:request(action, params, callback)
-	if not self.url then return callback(nil, "AnkiConnect URL missing") end
+function AnkiConnect:get_url()
+	local url = self.config.ankiconnect_url or "127.0.0.1:8765"
+	if not url:find("^http") then url = "http://" .. url end
+	return url
+end
 
+function AnkiConnect:request(action, params, callback)
+	local url = self:get_url()
 	local body = { action = action, version = DEFAULT_VERSION, params = params or {} }
 	if self.config.ankiconnect_api_key and self.config.ankiconnect_api_key ~= "" then
 		body.key = self.config.ankiconnect_api_key
@@ -32,7 +36,7 @@ function AnkiConnect:request(action, params, callback)
 	local json_body, _ = utils.format_json(body)
 	json_body = json_body:gsub('"params":%s*%[%s*%]', '"params":{}')
 
-	Api.request(self.curl, self.url, json_body, function(response, err)
+	Api.request(self.curl, url, json_body, function(response, err)
 		if err then return callback(nil, err) end
 		if response.error then return callback(nil, response.error) end
 		callback(response.result, nil)

--- a/scripts/yomipv/export/handler.lua
+++ b/scripts/yomipv/export/handler.lua
@@ -1149,11 +1149,8 @@ function Handler:init()
 	end
 end
 
-function Handler:toggle_colorizer()
-	self.config.colorizer_enabled = not self.config.colorizer_enabled
-	self.config.save("colorizer_enabled", self.config.colorizer_enabled)
+function Handler:sync_state()
 	if self.config.colorizer_enabled then
-		Player.notify("Colorizer: Enabled", "info", 2)
 		mp.set_property("sub-visibility", "no")
 		local sub = self.deps.tracker.export_current_session()
 		if sub and sub.primary_sid and sub.primary_sid ~= "" then
@@ -1167,10 +1164,16 @@ function Handler:toggle_colorizer()
 			self.deps.selector:clear_passive()
 		end
 	else
-		Player.notify("Colorizer: Disabled", "info", 2)
 		mp.set_property("sub-visibility", "yes")
 		self.deps.selector:clear_passive()
 	end
+end
+
+function Handler:toggle_colorizer()
+	self.config.colorizer_enabled = not self.config.colorizer_enabled
+	self.config.save("colorizer_enabled", self.config.colorizer_enabled)
+	Player.notify("Colorizer: " .. (self.config.colorizer_enabled and "Enabled" or "Disabled"), "info", 2)
+	self:sync_state()
 end
 
 function Handler:set_manual_start()

--- a/scripts/yomipv/lib/profiles.lua
+++ b/scripts/yomipv/lib/profiles.lua
@@ -1,0 +1,190 @@
+--[[ Profile system for switching named configuration sets ]]
+
+local mp = require("mp")
+local msg = require("mp.msg")
+
+local Profiles = {}
+
+-- Keys excluded from profile overwrites
+local SKIP_KEYS = {
+	current_profile = true,
+	key_cycle_profile = true,
+}
+
+-- Read key-value pairs from .conf file
+local function read_conf(path)
+	local result = {}
+	local file = io.open(path, "r")
+	if not file then return nil end
+	for line in file:lines() do
+		-- Strip comments and blank lines
+		local clean = line:match("^%s*([^#]-)%s*$")
+		if clean and clean ~= "" then
+			local key, val = clean:match("^([%w_]+)%s*=%s*(.-)%s*$")
+			if key and val then
+				result[key] = val
+			end
+		end
+	end
+	file:close()
+	return result
+end
+
+-- Coerce string value to default type
+local function coerce(raw, default)
+	local t = type(default)
+	if t == "boolean" then
+		return raw == "yes" or raw == "true" or raw == "1"
+	elseif t == "number" then
+		return tonumber(raw) or default
+	else
+		return raw
+	end
+end
+
+-- Apply configuration map to live table
+local function apply_conf(config, conf_map, defaults)
+	for key, raw_val in pairs(conf_map) do
+		if not SKIP_KEYS[key] and defaults[key] ~= nil then
+			config[key] = coerce(raw_val, defaults[key])
+		end
+	end
+end
+
+-- Locate script-opts directory
+local function get_opts_dir()
+	local path = mp.find_config_file("script-opts/yomipv.conf")
+	if path then
+		return path:match("^(.*[/\\])")
+	end
+	-- Fallback path expansion
+	local expanded = mp.command_native({ "expand-path", "~~/script-opts/" })
+	return expanded
+end
+
+-- List profiles from yomipv_*.conf files
+function Profiles.list(opts_dir)
+	local profiles = {}
+	local dir = opts_dir or get_opts_dir()
+	if not dir then return profiles end
+
+	-- Use mpv utils to list directory
+	local utils = require("mp.utils")
+	local entries = utils.readdir(dir, "files")
+	if not entries then return profiles end
+
+	for _, fname in ipairs(entries) do
+		local name = fname:match("^yomipv_(.+)%.conf$")
+		if name and name ~= "" then
+			table.insert(profiles, name)
+		end
+	end
+
+	table.sort(profiles)
+	return profiles
+end
+
+-- Load named profile into live table
+function Profiles.load(name, config, defaults)
+	local dir = get_opts_dir()
+	if not dir then
+		return false, "Cannot locate script-opts directory"
+	end
+
+	-- Reset to script defaults first
+	for k, v in pairs(defaults) do
+		if not SKIP_KEYS[k] then
+			config[k] = v
+		end
+	end
+
+	-- Apply base configuration (yomipv.conf)
+	local base_path = dir .. "yomipv.conf"
+	local base_map = read_conf(base_path)
+	if base_map then
+		apply_conf(config, base_map, defaults)
+	end
+
+	if name == "default" then
+		config.current_profile = "default"
+		msg.info("Loaded base profile (yomipv.conf)")
+		return true
+	end
+
+	local path = dir .. "yomipv_" .. name .. ".conf"
+	local conf_map = read_conf(path)
+	if not conf_map then
+		return false, "Profile file not found: " .. path
+	end
+
+	apply_conf(config, conf_map, defaults)
+	config.current_profile = name
+	msg.info("Loaded profile: " .. name .. " from " .. path)
+	return true
+end
+
+-- Cycle through available profiles
+function Profiles.cycle(config, defaults)
+	local dir = get_opts_dir()
+	local available = Profiles.list(dir)
+
+	local all = { "default" }
+	for _, p in ipairs(available) do
+		table.insert(all, p)
+	end
+
+	if #all <= 1 then
+		return nil, "No additional profiles found"
+	end
+
+	local current = config.current_profile or "default"
+	local next_idx = 1
+
+	for i, name in ipairs(all) do
+		if name == current then
+			next_idx = (i % #all) + 1
+			break
+		end
+	end
+
+	local next_name = all[next_idx]
+	local ok, err = Profiles.load(next_name, config, defaults)
+	if ok then
+		return next_name
+	else
+		return nil, err
+	end
+end
+
+-- Create profile from current configuration
+function Profiles.create(name, config)
+	local dir = get_opts_dir()
+	if not dir then return false, "Cannot locate script-opts directory" end
+	local path = dir .. "yomipv_" .. name .. ".conf"
+
+	local file = io.open(path, "w")
+	if not file then return false, "Failed to create file" end
+
+	file:write("# Yomipv Profile: " .. name .. "\n")
+	for k, v in pairs(config) do
+		if type(v) ~= "function" and type(v) ~= "table" and not SKIP_KEYS[k] then
+			local val_str = type(v) == "boolean" and (v and "yes" or "no") or tostring(v)
+			file:write(k .. "=" .. val_str .. "\n")
+		end
+	end
+	file:close()
+	return true
+end
+
+-- Delete profile file
+function Profiles.delete(name)
+	if name == "default" then return false, "Cannot delete default profile" end
+	local dir = get_opts_dir()
+	if not dir then return false, "Cannot locate script-opts directory" end
+	local path = dir .. "yomipv_" .. name .. ".conf"
+
+	local success, err = os.remove(path)
+	return success, err
+end
+
+return Profiles

--- a/scripts/yomipv/lib/string_ops.lua
+++ b/scripts/yomipv/lib/string_ops.lua
@@ -119,6 +119,9 @@ function StringOps.clean_title(title, path)
 	-- Strip extension once at the start
 	s = s:gsub("%.%w+$", "")
 
+	-- Truncate at SxxExx
+	s = s:gsub("[%.%s_%-]+[Ss]%d%d?[Ee]%d%d?.*", "")
+
 	-- Strip hex checksums
 	s = s:gsub("[%[%(]%x%x%x%x%x%x%x%x[%]%]%)]", "")
 
@@ -131,7 +134,8 @@ function StringOps.clean_title(title, path)
 		"1080[pP]", "720[pP]", "480[pP]", "2160[pP]", "1440[pP]", "576[pP]",
 		"[0-9]+[xX][0-9]+",
 		"[xX]26[45]", "[hH]%.?26[45]", "[hH][eE][vV][cC]",
-		"[aA][cC]3", "[aA][aA][cC]", "[mM][pP]3", "[fF][lL][aA][cC][0-9%.]*",
+		"[eE]?[%-]?[aA][cC]3", "[aA][aA][cC]", "[mM][pP]3", "[fF][lL][aA][cC][0-9%.]*",
+		"[dD][tT][sS]%-[hH][dD]", "[dD][tT][sS]", "[tT][rR][uU][eE][hH][dD]", "[oO][pP][uU][sS]",
 		"[dD][dD][pP][0-9%.]*", "[hH][iI]10[pP]?", "[0-9]+%-?bit",
 		"[nN][fF]", "[wW][eE][bB]%-?[dD][lL]", "[bB][lL][uU]%-?[rR][aA][yY]",
 		"[mM][uU][lL][tT][iI][^%s%.%-_]*", "[mM][sS][uU][bB][sS]?", "[dD][uU][aA][lL]",
@@ -142,6 +146,7 @@ function StringOps.clean_title(title, path)
 		"[bB][dD][rR][iI][pP]?", "[bB][dD]", "[tT][vV]", "[wW][eE][bB]",
 		"[vV][pP]9", "[aA][vV]1", "[xX][vV][iI][dD]",
 		"[sS][pP][eE][cC][iI][aA][lL]", "[oO][vV][aA]", "[oO][nN][aA]", "[oO][aA][dD]",
+		"[aA][tT][mM][oO][sS]", "[rR][eE][mM][uU][xX]",
 		"[aA][mM][zZ][nN]", "[jJ][pP][nN]", "[dD][sS][nN][pP]", "[cC][rR]", "[fF][uU][nN][iI]",
 		"[aA][bB][eE][mM][aA]", "[wW][oO][wW][oO][wW]", "[bB][sS]%-?[0-9]*", "[aA][tT]%-?[xX]",
 		"[mM][xX]", "[tT][vV][kK]", "[tT][vV][oO]", "[aA][nN][yY][iI][vV]", "[hH][iI][dD][iI][vV][eE]",
@@ -200,6 +205,9 @@ function StringOps.clean_title(title, path)
 		s = StringOps.trim(s)
 		s = s:gsub(pattern, "")
 	end
+
+	-- Strip trailing group tags and bracketed info
+	s = s:gsub("%s*[%[%(][^%]]-[%]%)]%s*$", "")
 
 	-- Strip trailing punctuation and delimiters
 	s = s:gsub("[%s%-%:_%.]+$", "")

--- a/scripts/yomipv/lookup-app/history.css
+++ b/scripts/yomipv/lookup-app/history.css
@@ -62,6 +62,8 @@ body.visible #history-container {
   font-weight: bold;
   letter-spacing: 1px;
   box-sizing: border-box;
+  user-select: none;
+  -webkit-user-select: none;
 }
 
 #header-title {
@@ -88,6 +90,10 @@ body.visible #history-container {
 
 .header-buttons button:hover, .header-buttons button.active {
   color: #ffffff;
+}
+
+#open-settings {
+  font-size: 18px !important;
 }
 
 #history-scroll-clip {

--- a/scripts/yomipv/lookup-app/history.html
+++ b/scripts/yomipv/lookup-app/history.html
@@ -12,6 +12,7 @@
       <div class="header-buttons">
         <button id="anim-toggle">GIF: OFF</button>
         <button id="clear-history">CLEAR</button>
+        <button id="open-settings">⚙</button>
       </div>
     </div>
     <div id="history-scroll-clip">

--- a/scripts/yomipv/lookup-app/history.js
+++ b/scripts/yomipv/lookup-app/history.js
@@ -4,6 +4,7 @@ const listContainer = document.getElementById('history-list');
 const scrollClip = document.getElementById('history-scroll-clip');
 const headerTitle = document.getElementById('header-title');
 const animToggle = document.getElementById('anim-toggle');
+const settingsBtn = document.getElementById('open-settings');
 const clearBtn = document.getElementById('clear-history');
 
 let isAppending = false;
@@ -233,6 +234,10 @@ ipcRenderer.on('hide-history', () => {
 
 animToggle.addEventListener('click', () => {
   ipcRenderer.send('history-toggle-anim');
+});
+
+settingsBtn.addEventListener('click', () => {
+  ipcRenderer.send('open-settings');
 });
 
 clearBtn.addEventListener('click', () => {

--- a/scripts/yomipv/lookup-app/main.js
+++ b/scripts/yomipv/lookup-app/main.js
@@ -5,12 +5,16 @@ const net = require('net');
 
 let mainWindow;
 let historyWindow = null;
+let settingsWindow = null;
 let pendingHide = false;
 let historyHideTimeout = null;
 let lastSelectedDictHtml = '';
+let tray = null;
 
 let lookupSuspended = false;
 let lookupSuspendTimeout = null;
+
+const appIconPath = path.join(__dirname, 'build', 'lookup-app.png');
 
 let isContextMenuOpen = false;
 let appIsFocused = true;
@@ -26,13 +30,16 @@ function isHistoryDevToolsOpen() {
   return !!(historyWindow && historyWindow.webContents.isDevToolsOpened());
 }
 
+let mpvIpcQueue = [];
+
 // Sends JSON command to mpv IPC pipe
 function sendMpvMessage(message, ...args) {
   if (mpvIpc) {
     const cmd = { command: [message, ...args] };
     mpvIpc.write(JSON.stringify(cmd) + '\n');
   } else {
-    console.warn(`[IPC] Cannot send ${message}: mpvIpc not connected`);
+    console.warn(`[IPC] Queuing ${message}: mpvIpc not connected`);
+    mpvIpcQueue.push([message, ...args]);
   }
 }
 
@@ -50,6 +57,7 @@ function createWindow() {
     maximizable: false,
     alwaysOnTop: true,
     type: 'toolbar', 
+    icon: appIconPath,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false
@@ -88,6 +96,7 @@ function createHistoryWindow() {
     maximizable: false,
     alwaysOnTop: true,
     type: 'toolbar',
+    icon: appIconPath,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false
@@ -101,6 +110,48 @@ function createHistoryWindow() {
   historyWindow.loadFile('history.html');
 }
 
+// Show settings window
+function createSettingsWindow() {
+  if (settingsWindow) {
+    settingsWindow.show();
+    settingsWindow.focus();
+    return;
+  }
+
+  settingsWindow = new BrowserWindow({
+    width: 900,
+    height: 700,
+    frame: false,
+    show: false,
+    icon: appIconPath,
+    webPreferences: {
+      nodeIntegration: true,
+      contextIsolation: false
+    }
+  });
+
+  settingsWindow.loadFile('settings.html');
+  settingsWindow.once('ready-to-show', () => settingsWindow.show());
+  settingsWindow.on('closed', () => settingsWindow = null);
+}
+
+function createTray() {
+  const iconPath = path.join(__dirname, 'build', 'lookup-app.png');
+  const icon = nativeImage.createFromPath(iconPath).resize({ width: 16, height: 16 });
+  tray = new Tray(icon);
+  const contextMenu = Menu.buildFromTemplate([
+    { label: 'Yomipv Lookup', enabled: false },
+    { type: 'separator' },
+    { label: 'Settings', click: () => createSettingsWindow() },
+    { label: 'History', click: () => sendMpvMessage('script-message', 'yomipv-toggle-history') },
+    { type: 'separator' },
+    { label: 'Quit', click: () => app.quit() }
+  ]);
+  tray.setToolTip('Yomipv');
+  tray.setContextMenu(contextMenu);
+  tray.on('double-click', () => createSettingsWindow());
+}
+
 // mpv IPC pipe path from CLI argument
 const ipcPipeArg = process.argv.find(arg => arg.startsWith('--ipc-pipe='));
 const ipcPipe = ipcPipeArg ? ipcPipeArg.split('=')[1] : null;
@@ -111,6 +162,10 @@ if (ipcPipe) {
     console.log('[IPC] Connecting to:', ipcPipe);
     mpvIpc = net.connect(ipcPipe, () => {
       console.log('[IPC] Connected to mpv');
+      while (mpvIpcQueue.length > 0) {
+        const [msg, ...args] = mpvIpcQueue.shift();
+        sendMpvMessage(msg, ...args);
+      }
     });
     mpvIpc.on('error', (err) => {
       console.warn('[IPC] mpv connection error:', err.message);
@@ -126,8 +181,12 @@ if (ipcPipe) {
 }
 
 app.whenReady().then(() => {
+  if (process.platform === 'win32') {
+    app.setAppUserModelId('com.yomipv.lookup');
+  }
   createWindow();
   createHistoryWindow();
+  createTray();
 
   // HTTP server for terms and commands from mpv Lua
   const server = http.createServer((req, res) => {
@@ -183,6 +242,13 @@ app.whenReady().then(() => {
             pendingHide = true;
             mainWindow.webContents.send('window-hide-request');
           }
+          return;
+        }
+
+        if (req.url === '/settings-open') {
+          console.log('[IPC] Settings open signal received');
+          res.end('ok');
+          createSettingsWindow();
           return;
         }
 
@@ -246,6 +312,34 @@ app.whenReady().then(() => {
             }
           } catch (e) {
             console.error('Failed to parse history body', e);
+          }
+          res.end('ok');
+          return;
+        }
+
+        if (req.url === '/settings-data') {
+          console.log('[IPC] Settings data received');
+          try {
+            const data = JSON.parse(body);
+            if (settingsWindow) {
+              settingsWindow.webContents.send('settings-data', data);
+            }
+          } catch (e) {
+            console.error('Failed to parse settings body', e);
+          }
+          res.end('ok');
+          return;
+        }
+
+        if (req.url === '/profile-list-data') {
+          console.log('[IPC] Profile list received');
+          try {
+            const data = JSON.parse(body);
+            if (settingsWindow) {
+              settingsWindow.webContents.send('profile-list', data);
+            }
+          } catch (e) {
+            console.error('Failed to parse profile list body', e);
           }
           res.end('ok');
           return;
@@ -594,4 +688,38 @@ ipcMain.on('history-set-ignore-mouse', (event, ignore) => {
   if (historyWindow) {
     historyWindow.setIgnoreMouseEvents(ignore, { forward: true });
   }
+});
+
+// Settings and profiles IPC
+ipcMain.on('open-settings', () => {
+  createSettingsWindow();
+});
+
+ipcMain.on('settings-window-ready', (event) => {
+  sendMpvMessage('script-message', 'yomipv-get-settings');
+});
+
+ipcMain.on('settings-set', (event, { key, value }) => {
+  sendMpvMessage('script-message', 'yomipv-set-setting', key, value.toString());
+});
+
+ipcMain.on('profile-list-request', () => {
+  sendMpvMessage('script-message', 'yomipv-list-profiles');
+});
+
+ipcMain.on('profile-switch', (event, name) => {
+  sendMpvMessage('script-message', 'yomipv-switch-profile', name);
+});
+
+ipcMain.on('profile-create', (event, name) => {
+  sendMpvMessage('script-message', 'yomipv-create-profile', name);
+});
+
+ipcMain.on('profile-delete', (event, name) => {
+  sendMpvMessage('script-message', 'yomipv-delete-profile', name);
+});
+
+// Incoming from MPV
+ipcMain.on('profile-list', (event, profiles) => {
+  if (settingsWindow) settingsWindow.webContents.send('profile-list', profiles);
 });

--- a/scripts/yomipv/lookup-app/settings.css
+++ b/scripts/yomipv/lookup-app/settings.css
@@ -1,0 +1,475 @@
+:root {
+  --bg-color: #0d0d0d;
+  --sidebar-bg: #141414;
+  --text-color: #e0e0e0;
+  --text-dim: #999;
+  --accent-color: #3db54a;
+  --accent-dim: #2a7e33;
+  --border-color: #222;
+  --input-bg: #1a1a1a;
+  --hover-bg: #1f1f1f;
+  --active-bg: #2a2a2a;
+  --kbd-bg: #222;
+  --kbd-border: #333;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-color);
+  background-color: var(--bg-color);
+  height: 100vh;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  user-select: none;
+}
+
+/* Titlebar */
+#titlebar {
+  height: 40px;
+  background-color: var(--sidebar-bg);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  -webkit-app-region: drag;
+  border-bottom: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+#titlebar-icon {
+  margin-right: 10px;
+  font-size: 16px;
+  color: var(--accent-color);
+}
+
+#titlebar-title {
+  flex-grow: 1;
+  font-weight: 600;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+}
+
+#titlebar-close {
+  -webkit-app-region: no-drag;
+  background: transparent;
+  border: none;
+  color: var(--text-dim);
+  font-size: 16px;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+  transition: all 0.2s;
+}
+
+#titlebar-close:hover {
+  background-color: #c42b1c;
+  color: white;
+}
+
+/* Layout */
+#layout {
+  display: flex;
+  flex-grow: 1;
+  overflow: hidden;
+}
+
+/* Sidebar */
+#sidebar {
+  width: 150px;
+  flex-shrink: 0;
+  background-color: var(--sidebar-bg);
+  border-right: 1px solid var(--border-color);
+  padding: 16px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  overflow-y: auto;
+}
+
+.nav-section-label {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  color: var(--text-dim);
+  margin: 16px 8px 4px;
+  letter-spacing: 0.05em;
+}
+
+.nav-section-label:first-child {
+  margin-top: 0;
+}
+
+.nav-item {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  text-align: left;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.2s;
+  font-size: 13px;
+}
+
+.nav-item:hover {
+  background-color: var(--hover-bg);
+}
+
+.nav-item.active {
+  background-color: var(--active-bg);
+  color: var(--accent-color);
+}
+
+.nav-icon {
+  display: none;
+}
+
+/* Scrollbar styling */
+::-webkit-scrollbar {
+  width: 12px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.5);
+  border-radius: 10px;
+  border: 4px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.8);
+  border: 4px solid transparent;
+  background-clip: padding-box;
+}
+
+::-webkit-scrollbar-button {
+  display: block;
+  height: 6px;
+  background-color: transparent;
+}
+
+::-webkit-scrollbar-button:vertical:start:decrement,
+::-webkit-scrollbar-button:vertical:end:increment {
+  display: block;
+  height: 6px;
+  background-color: transparent;
+}
+
+/* Main content */
+#content {
+  flex-grow: 1;
+  overflow-y: auto;
+  padding: 24px 40px;
+  background-color: var(--bg-color);
+}
+
+.settings-section {
+  max-width: 800px;
+}
+
+.settings-section h2 {
+  font-size: 26px;
+  font-weight: 700;
+  margin-bottom: 4px;
+}
+
+.section-desc {
+  color: var(--text-dim);
+  margin-bottom: 20px;
+  font-size: 13px;
+  line-height: 1.6;
+}
+
+.hidden {
+  display: none !important;
+}
+
+/* Fields */
+.field-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.field-section-header {
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-top: 24px;
+  margin-bottom: 8px;
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-color);
+}
+
+.field {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  align-items: center;
+  gap: 8px 16px;
+  padding: 12px 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.02);
+}
+
+.field:last-child {
+  border-bottom: none;
+}
+
+.field-label {
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--text-color);
+}
+
+.field-desc {
+  grid-column: 2;
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: -4px;
+}
+
+.field-input-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.checkbox-container {
+  display: flex;
+  align-items: center;
+  height: 32px;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="password"],
+select {
+  background-color: var(--input-bg);
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
+  padding: 8px 12px;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 13.5px;
+  width: 100%;
+  max-width: 400px;
+  outline: none;
+  transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+input:hover, select:hover {
+  border-color: #444;
+  background-color: var(--hover-bg);
+}
+
+input:focus, select:focus {
+  border-color: var(--accent-color);
+  background-color: var(--active-bg);
+  box-shadow: 0 0 0 1px var(--accent-color);
+}
+
+.keybind-input {
+  cursor: pointer;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+
+.keybind-input.recording {
+  background-color: var(--accent-dim);
+  border-color: var(--accent-color);
+  color: #fff;
+  animation: pulse 1.5s infinite;
+}
+
+@keyframes pulse {
+  0% { opacity: 1; }
+  50% { opacity: 0.6; }
+  100% { opacity: 1; }
+}
+
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+}
+
+input[type="checkbox"] {
+  accent-color: var(--accent-color);
+  width: 16px;
+  height: 16px;
+}
+
+/* Profiles */
+.profile-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background-color: var(--sidebar-bg);
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--border-color);
+  margin-bottom: 24px;
+}
+
+.profile-active {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.profile-dot {
+  width: 8px;
+  height: 8px;
+  background-color: var(--accent-color);
+  border-radius: 50%;
+  box-shadow: 0 0 8px var(--accent-color);
+}
+
+.profile-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 12px;
+  margin-bottom: 32px;
+}
+
+.profile-card {
+  background-color: var(--sidebar-bg);
+  border: 2px solid var(--border-color);
+  padding: 16px;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: all 0.2s;
+}
+
+.profile-card:hover {
+  border-color: #333;
+}
+
+.profile-card.active {
+  border-color: var(--accent-color);
+  background-color: rgba(61, 181, 74, 0.05);
+}
+
+.profile-name {
+  font-weight: 700;
+  font-size: 15px;
+}
+
+.profile-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.btn-primary, .btn-secondary, .btn-danger {
+  border: none;
+  padding: 6px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.btn-primary {
+  background-color: var(--accent-color);
+  color: #000;
+}
+
+.btn-primary:hover {
+  background-color: #4cd35b;
+}
+
+.btn-secondary {
+  background-color: #222;
+  color: var(--text-color);
+  border: 1px solid #333;
+}
+
+.btn-secondary:hover {
+  background-color: #333;
+}
+
+.btn-danger {
+  background-color: #442222;
+  color: #ff9999;
+}
+
+.btn-danger:hover {
+  background-color: #662222;
+}
+
+.profile-create {
+  background-color: var(--sidebar-bg);
+  padding: 24px;
+  border-radius: 8px;
+  border: 1px dashed #333;
+}
+
+.profile-create label {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.input-row {
+  display: flex;
+  gap: 12px;
+}
+
+.hint {
+  font-size: 12px;
+  color: var(--text-dim);
+  margin-top: 12px;
+}
+
+kbd {
+  background-color: var(--kbd-bg);
+  border: 1px solid var(--kbd-border);
+  padding: 2px 5px;
+  border-radius: 3px;
+  font-family: monospace;
+  font-size: 11px;
+}
+
+/* Toast */
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: #111;
+  border: 1px solid var(--accent-dim);
+  color: var(--accent-color);
+  padding: 10px 20px;
+  border-radius: 30px;
+  font-weight: 600;
+  z-index: 1000;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+  transition: all 0.3s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+}
+
+.toast.hidden {
+  bottom: -50px;
+  opacity: 0;
+}

--- a/scripts/yomipv/lookup-app/settings.html
+++ b/scripts/yomipv/lookup-app/settings.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Yomipv Settings</title>
+  <link rel="stylesheet" href="settings.css">
+</head>
+<body>
+  <div id="titlebar">
+    <span id="titlebar-title">Yomipv Settings</span>
+    <button id="titlebar-close" title="Close">✕</button>
+  </div>
+
+  <div id="layout">
+    <nav id="sidebar">
+      <button class="nav-item active" data-section="general" id="nav-general">
+        General
+      </button>
+
+      <button class="nav-item" data-section="anki" id="nav-anki">
+        Anki
+      </button>
+
+      <button class="nav-item" data-section="yomitan" id="nav-yomitan">
+        Yomitan
+      </button>
+
+      <button class="nav-item" data-section="picture" id="nav-picture">
+        Picture
+      </button>
+
+      <button class="nav-item" data-section="audio" id="nav-audio">
+        Audio
+      </button>
+
+      <button class="nav-item" data-section="selector" id="nav-selector">
+        Selector
+      </button>
+
+      <button class="nav-item" data-section="history" id="nav-history">
+        History
+      </button>
+
+      <button class="nav-item" data-section="subtitles" id="nav-subtitles">
+        Subtitles
+      </button>
+
+      <button class="nav-item" data-section="anilist" id="nav-anilist">
+        Anilist
+      </button>
+
+      <button class="nav-item" data-section="updater" id="nav-updater">
+        Updater
+      </button>
+
+      <button class="nav-item" data-section="mpv" id="nav-mpv">
+        MPV Settings
+      </button>
+    </nav>
+
+    <main id="content">
+      <section class="settings-section" id="section-general">
+        <h2>General</h2>
+        <div class="field-group" id="fields-general"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-anki">
+        <h2>Anki Settings</h2>
+        <div class="field-group" id="fields-anki"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-yomitan">
+        <h2>Yomitan</h2>
+        <div class="field-group" id="fields-yomitan"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-picture">
+        <h2>Picture</h2>
+        <div class="field-group" id="fields-picture"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-audio">
+        <h2>Audio</h2>
+        <div class="field-group" id="fields-audio"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-selector">
+        <h2>Selector</h2>
+        <div class="field-group" id="fields-selector"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-history">
+        <h2>History Panel</h2>
+        <div class="field-group" id="fields-history"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-subtitles">
+        <h2>Subtitles</h2>
+        <div class="field-group" id="fields-subtitles"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-anilist">
+        <h2>Anilist</h2>
+        <div class="field-group" id="fields-anilist"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-updater">
+        <h2>Updater</h2>
+        <div class="field-group" id="fields-updater"></div>
+      </section>
+
+      <section class="settings-section hidden" id="section-mpv">
+        <h2>MPV Settings</h2>
+        <div class="field-group" id="fields-mpv"></div>
+      </section>
+    </main>
+  </div>
+
+  <div id="toast" class="toast hidden"></div>
+  <script src="settings.js"></script>
+</body>
+</html>

--- a/scripts/yomipv/lookup-app/settings.js
+++ b/scripts/yomipv/lookup-app/settings.js
@@ -1,0 +1,562 @@
+const { ipcRenderer } = require('electron');
+
+let currentConfig = {};
+let activeProfile = 'default';
+let lastProfileList = [];
+
+// Navigation
+document.querySelectorAll('.nav-item').forEach(btn => {
+  btn.onclick = () => {
+    const sectionId = btn.dataset.section;
+    document.querySelectorAll('.nav-item').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.settings-section').forEach(s => s.classList.add('hidden'));
+    
+    btn.classList.add('active');
+    document.getElementById(`section-${sectionId}`).classList.remove('hidden');
+  };
+});
+
+// Close button
+document.getElementById('titlebar-close').onclick = () => {
+  window.close();
+};
+
+// Toast notification
+function showToast(msg) {
+  const toast = document.getElementById('toast');
+  toast.textContent = msg;
+  toast.classList.remove('hidden');
+  setTimeout(() => toast.classList.add('hidden'), 3000);
+}
+
+// Settings field rendering
+const fieldConfigs = {
+  general: [
+    { type: 'header', label: 'Profiles' },
+    { type: 'profiles-manager' },
+    { type: 'header', label: 'Keybindings' },
+    { key: 'key_cycle_profile', label: 'Cycle Profiles', type: 'keybind' },
+    { key: 'key_open_settings', label: 'Open Settings', type: 'keybind' }
+  ],
+  anki: [
+    { type: 'header', label: 'AnkiConnect' },
+    { key: 'ankiconnect_url', label: 'AnkiConnect URL', type: 'text' },
+    { key: 'ankiconnect_api_key', label: 'API Key', type: 'password' },
+    { key: 'ankidb_fields', label: 'Anki DB build settings', type: 'text' },
+    { key: 'update_if_exists', label: 'Update if exists', type: 'checkbox', desc: 'Append media if card already exists' },
+    { key: 'refresh_gui_after_update', label: 'Refresh Anki GUI', type: 'checkbox', desc: 'Reload Anki browser after export' },
+
+    { type: 'header', label: 'Deck and Note Type' },
+    { key: 'deck', label: 'Target Deck', type: 'text' },
+    { key: 'note_type', label: 'Note Type', type: 'text' },
+
+    { type: 'header', label: 'Note Type Fields' },
+    { key: 'expression_field', label: 'Expression', type: 'text' },
+    { key: 'expression_furigana_field', label: 'Expression Furigana', type: 'text' },
+    { key: 'reading_field', label: 'Reading', type: 'text' },
+    { key: 'pitch_accents_field', label: 'Pitch Accents', type: 'text' },
+    { key: 'pitch_position_field', label: 'Pitch Position', type: 'text' },
+    { key: 'pitch_categories_field', label: 'Pitch Categories', type: 'text' },
+    { key: 'sentence_field', label: 'Sentence', type: 'text' },
+    { key: 'sentence_furigana_field', label: 'Sentence Furigana', type: 'text' },
+    { key: 'secondary_sentence_field', label: 'Translation Field', type: 'text' },
+    { key: 'expression_audio_field', label: 'Word Audio', type: 'text' },
+    { key: 'sentence_audio_field', label: 'Sentence Audio', type: 'text' },
+    { key: 'selection_text_field', label: 'Selection Text', type: 'text' },
+    { key: 'definition_field', label: 'Definition', type: 'text' },
+    { key: 'glossary_field', label: 'Glossary', type: 'text' },
+    { key: 'image_field', label: 'Image', type: 'text' },
+    { key: 'freq_sort_field', label: 'Frequency Sort', type: 'text' },
+    { key: 'freq_field', label: 'Frequency', type: 'text' },
+    { key: 'miscinfo_field', label: 'Misc Info', type: 'text' },
+
+    { type: 'header', label: 'Senren Exclusive' },
+    { key: 'dictionary_pref_field', label: 'Dictionary Pref Field', type: 'text' },
+    { key: 'dictionary_pref_value', label: 'Dictionary Pref', type: 'text' },
+    { key: 'primary_sentence_wrapper', label: 'Primary Sentence Wrapper', type: 'text' },
+    { key: 'secondary_sentence_wrapper', label: 'Secondary Sentence Wrapper', type: 'text' },
+    { key: 'miscinfo_wrapper', label: 'Misc Info Wrapper', type: 'text' },
+
+    { type: 'header', label: 'Note Tagging' },
+    { key: 'note_tag', label: 'Note Tag', type: 'text' },
+
+    { type: 'header', label: 'Misc Info Settings' },
+    { key: 'miscinfo_episode_bullet', label: 'Use Bullet Logic', type: 'checkbox' },
+    { key: 'miscinfo_show_season_one', label: 'Show Season 1 Index', type: 'checkbox' },
+    { key: 'miscinfo_show_ms', label: 'Show Milliseconds', type: 'checkbox' },
+    { key: 'miscinfo_episode_label', label: 'Episode Label', type: 'text' },
+    { key: 'miscinfo_season_label', label: 'Season Label', type: 'text' },  
+    { key: 'miscinfo_format', label: 'Format String', type: 'text' },
+
+    { type: 'header', label: 'Media Templates' },
+    { key: 'audio_template', label: 'Audio Template', type: 'text' },
+    { key: 'image_template', label: 'Image Template', type: 'text' }
+  ],
+
+  yomitan: [
+    { key: 'yomitan_url', label: 'Yomitan URL', type: 'text' },
+    { type: 'header', label: 'Handlebars' },
+    { key: 'selection_text_handlebar', label: 'Selection Handlebar', type: 'text' },
+    { key: 'definition_handlebar', label: 'Definition Handlebar', type: 'text' },
+    { key: 'glossary_handlebar', label: 'Glossary Handlebar', type: 'text' },
+    { type: 'header', label: 'Sentence Highlight' },
+    { key: 'sentence_highlight_tag', label: 'Sentence Highlight Tag', type: 'text' }
+  ],
+
+  picture: [
+    { type: 'header', label: 'Picture Settings' },
+    { key: 'picture_use_ffmpeg', label: 'Use FFmpeg (Picture)', type: 'checkbox' },
+    { 
+      key: 'picture_timestamp_source', 
+      label: 'Timestamp Source', 
+      type: 'select',
+      options: [
+        { label: 'Subtitle Start', value: 'subtitle_start' },
+        { label: 'Current Position', value: 'current_position' }
+      ]
+    },
+    { key: 'picture_animated', label: 'Capture images as animations', type: 'checkbox' },
+
+    { type: 'header', label: 'Static Screenshot Settings' },
+    { key: 'picture_static_format', label: 'Image Format', type: 'select',
+      options: [
+        { label: 'webp', value: 'webp'},
+        { label: 'avif', value: 'avif' },
+        { label: 'jpg', value: 'jpg' }
+      ] 
+    },
+    { key: 'picture_static_quality', label: 'Image Quality', type: 'number', desc: '1-100' },
+    { key: 'picture_static_width', label: 'Static Width', type: 'number' },
+    { key: 'picture_static_offset', label: 'Static Offset', type: 'number' },
+
+    { type: 'header', label: 'Animated Picture Settings' },
+    { key: 'animation_format', label: 'Animation Format', type: 'select',
+      options: [
+        { label: 'webp', value: 'webp' },
+        { label: 'avif', value: 'avif' }
+      ]
+    },
+    { key: 'animation_quality', label: 'GIF Quality', type: 'number' },
+    { key: 'animation_width', label: 'Animation Width', type: 'number' },
+    { key: 'animation_fps', label: 'GIF FPS', type: 'number' },
+    { key: 'animation_duration', label: 'Animation Duration', type: 'text' },
+    { key: 'animation_offset', label: 'GIF Start Offset', type: 'number' },
+    { key: 'animation_end_offset', label: 'GIF End Offset', type: 'number' },
+    
+    { type: 'header', label: 'Advanced Codec Settings' },
+    { key: 'picture_webp_lossless', label: 'WebP Lossless', type: 'checkbox' },
+    { key: 'picture_webp_compression', label: 'WebP Compression', type: 'number', desc: '0-6' },
+    { key: 'picture_avif_cpu_used', label: 'AVIF CPU Used', type: 'number', desc: '0-8' },
+  ],
+
+  audio: [
+    { key: 'audio_use_ffmpeg', label: 'Use FFmpeg (Audio)', type: 'checkbox' },
+    { key: 'audio_format', label: 'Audio Format', type: 'select',
+      options: [
+        { label: 'opus', value: 'opus' },
+        { label: 'mp3', value: 'mp3' },
+        { label: 'ogg', value: 'ogg' },
+        { label: 'wav', value: 'wav' }
+      ]
+    },
+    { key: 'audio_bitrate', label: 'Audio Bitrate', type: 'text' },
+    { key: 'audio_offset', label: 'Audio Start Offset', type: 'number' },
+    { key: 'audio_end_offset', label: 'Audio End Offset', type: 'number' },
+    { type: 'header', label: 'Misc' },
+    { key: 'audio_match_volume', label: 'Match Volume', type: 'checkbox' },
+    { key: 'filename_show_ms', label: 'MS in Filenames', type: 'checkbox' }
+  ],
+
+  selector: [
+    { key: 'pre_tokenize', label: 'Pre-tokenize Subtitles', type: 'checkbox' },
+    { key: 'selector_show_history', label: 'Show History in Selector', type: 'checkbox' },
+    { key: 'selector_hide_ui', label: 'Hide Player UI', type: 'checkbox' },
+    { key: 'selector_navigation_delay', label: 'Navigation Delay', type: 'number', desc: 'Input delay between repeated navigation actions' },
+    { key: 'selector_trigger_on_mouse_move', label: 'Mouse Trigger', type: 'checkbox' },
+    { key: 'selector_trigger_mouse_idle_time', label: 'Mouse Idle Time', type: 'number', desc: 'Seconds before trigger' },
+
+    { type: 'header', label: 'Colorizer' },
+    { key: 'colorizer_enabled', label: 'Enable Colorizer', type: 'checkbox' },
+    { key: 'selector_colorize_words', label: 'Colorize Words', type: 'checkbox' },
+    { key: 'selector_colorize_underline', label: 'Colorize Underline', type: 'checkbox' },
+    
+    { type: 'header', label: 'Lookup Settings' },
+    { key: 'selector_lookup_on_hover', label: 'Open Lookup on hover', type: 'checkbox' },
+    { key: 'selector_lookup_on_navigation', label: 'Open Lookup on navigation', type: 'checkbox' },
+    { key: 'selector_lookup_delay', label: 'Lookup Delay', type: 'number', desc: 'Delay before lookup opens on hover/navigation' },
+    { key: 'selector_mora_hover', label: 'Mora Hover', type: 'checkbox' },
+    { key: 'selector_mora_navigation', label: 'Mora Navigation', type: 'checkbox' },
+    { key: 'lookup_show_frequencies', label: 'Show Frequencies', type: 'checkbox' },
+    { key: 'lookup_show_pitch_accents', label: 'Show Pitch Accents', type: 'checkbox' },
+    { key: 'prioritize_kanji_match', label: 'Prioritize Kanji', type: 'checkbox' },
+    { key: 'prioritize_hiragana_match', label: 'Prioritize Hiragana', type: 'checkbox' },
+
+    { type: 'header', label: 'Appearance' },
+    { key: 'lookup_theme', label: 'Theme', type: 'select',
+      options: [
+        { label: 'Dark', value: 'dark' },
+        { label: 'Light', value: 'light' }
+      ]
+    },
+
+    { type: 'header', label: 'Typography' },
+    { key: 'selector_font_name', label: 'Selector Font', type: 'text' },
+    { key: 'selector_font_size', label: 'Selector Font Size', type: 'number' },
+    { key: 'selector_line_height', label: 'Line Height', type: 'number' },
+
+    { type: 'header', label: 'Appearance' },
+    { key: 'selector_selection_underline', label: 'Underline Selection', type: 'checkbox' },
+    { key: 'selector_underline_thickness', label: 'Underline Thickness', type: 'number' },
+    { key: 'selector_underline_offset', label: 'Underline Offset', type: 'number' },
+    { key: 'selector_border_size', label: 'Border Size', type: 'number' },
+    { key: 'selector_shadow_offset', label: 'Shadow Offset', type: 'number' },
+
+    { type: 'header', label: 'Colors' },
+    { key: 'selector_color', label: 'Text Color', type: 'text' },
+    { key: 'selector_selection_color', label: 'Selection Color', type: 'text' },
+    { key: 'selector_lock_color', label: 'Lock Color', type: 'text' },
+    { key: 'selector_persistent_color', label: 'Persistent Color', type: 'text' },
+    { key: 'selector_border_color', label: 'Border Color', type: 'text' },
+    { key: 'selector_shadow_color', label: 'Shadow Color', type: 'text' },
+    
+    { type: 'header', label: 'Layout' },
+    { key: 'selector_pos_y', label: 'Vertical Position', type: 'number', desc: '0.0 - 1.0' },
+    { key: 'selector_max_width_factor', label: 'Max Width Factor', type: 'number', desc: '0.0 - 1.0' },
+
+    { type: 'header', label: 'Keybindings' },
+    { key: 'key_toggle_colorizer', label: 'Toggle Colorizer', type: 'keybind' },
+    { key: 'key_open_selector', label: 'Open Selector', type: 'keybind' },
+    { key: 'key_selector_confirm', label: 'Selector Confirm', type: 'keybind' },
+    { key: 'key_selector_cancel', label: 'Selector Cancel', type: 'keybind' },
+    { key: 'key_selector_left', label: 'Selector Left', type: 'keybind' },
+    { key: 'key_selector_right', label: 'Selector Right', type: 'keybind' },
+    { key: 'key_selector_up', label: 'Selector Up', type: 'keybind' },
+    { key: 'key_selector_down', label: 'Selector Down', type: 'keybind' },
+    { key: 'key_expand_prev', label: 'Expand Prev', type: 'keybind' },
+    { key: 'key_expand_next', label: 'Expand Next', type: 'keybind' },
+    { key: 'key_selector_lookup', label: 'Selector Lookup', type: 'keybind' },
+    { key: 'key_selector_lock', label: 'Selector Lock', type: 'keybind' },
+    { key: 'key_toggle_mora_navigation', label: 'Toggle Mora Navigation', type: 'keybind' },
+    { key: 'key_toggle_selector_trigger_on_mouse_move', label: 'Toggle Selector Trigger on Mouse Move', type: 'keybind' },
+    { key: 'key_append_mode', label: 'Append Mode', type: 'keybind' },
+    { key: 'key_set_timing_start', label: 'Set Timing Start', type: 'keybind' },
+    { key: 'key_set_timing_end', label: 'Set Timing End', type: 'keybind' },
+    { key: 'key_clear_timings', label: 'Clear Timings', type: 'keybind' },
+    { key: 'key_build_ankidb', label: 'Build AnkiDB', type: 'keybind' },
+    { key: 'key_toggle_picture_animated', label: 'Toggle Picture Animated', type: 'keybind' }
+  ],
+
+  history: [
+    { key: 'history_show_secondary', label: 'Show Translations', type: 'checkbox' },
+    { key: 'history_hide_volume', label: 'Hide Volume Slider', type: 'checkbox', desc: 'Hide uosc volume while panel is open' },
+    { key: 'history_max_entries', label: 'Max History Entries', type: 'number' },
+
+    { type: 'header', label: 'Size' },
+    { key: 'history_width', label: 'Panel Width', type: 'number' },
+    { key: 'history_max_height', label: 'Panel Max Height', type: 'text', desc: 'e.g. 60vh or 500px' },
+
+    { type: 'header', label: 'Typography' },
+    { key: 'history_font_size', label: 'Font Size', type: 'number' },
+    { key: 'history_secondary_font_size', label: 'History Sub Font Size', type: 'number' },
+    { key: 'history_font_family', label: 'History Font', type: 'text' },
+
+    { type: 'header', label: 'Appearance' },
+    { key: 'history_accent_color', label: 'History Accent', type: 'text' },
+    { key: 'history_header_background_color', label: 'History Header BG', type: 'text' },
+    { key: 'history_background_color', label: 'History BG', type: 'text' },
+    { key: 'history_background_opacity', label: 'History Opacity', type: 'text' },
+    { key: 'history_border_radius', label: 'History Radius', type: 'number' },
+
+    { type: 'header', label: 'Keybindings' },
+    { key: 'key_toggle_history', label: 'Toggle History', type: 'keybind' },
+    { key: 'key_history_clear', label: 'Clear History', type: 'keybind' }
+  ],
+
+  subtitles: [
+    { key: 'subtitle_filter_enabled', label: 'Filter Subtitles', type: 'checkbox' },
+
+    { type: 'header', label: 'Primary Subtitle' },
+    { key: 'primary_autoload', label: 'Auto-load Subs', type: 'checkbox' },
+    { key: 'primary_sub_lang', label: 'Subtitle Language', type: 'text', desc: 'Preferred languages for primary subtitles' },
+    { key: 'primary_sub_exclude', label: 'Excluded Keywords', type: 'text', desc: 'Skip tracks with matching keywords' },
+    { key: 'auto_sync_subtitles', label: 'Auto Sync Timing', type: 'checkbox', desc: 'Automatically sync primary subtitle timing to secondary if languages match' },
+
+    { type: 'header', label: 'Secondary Subtitle' },
+    { key: 'secondary_sid', label: 'Secondary Subtitle', type: 'checkbox' },
+    { key: 'secondary_on_hover', label: 'Secondary on Hover', type: 'checkbox' },
+    { key: 'secondary_sub_lang', label: 'Subtitle Language', type: 'text', desc: 'Preferred languages for secondary subtitles' },
+    { key: 'secondary_sub_exclude', label: 'Excluded Keywords', type: 'text', desc: 'Skip tracks with matching keywords' },
+
+    { type: 'header', label: 'Keybindings' },
+    { key: 'key_sub_seek_next', label: 'Seek Next', type: 'keybind', desc: 'Jump to next subtitle line' },
+    { key: 'key_sub_seek_prev', label: 'Seek Previous', type: 'keybind', desc: 'Jump to previous subtitle line' },
+    { key: 'key_secondary_sub_next', label: 'Next Secondary Sub', type: 'keybind' },
+    { key: 'key_secondary_sub_prev', label: 'Previous Secondary Sub', type: 'keybind' },
+    { key: 'key_sync_subtitles', label: 'Sync Subtitles', type: 'keybind', desc: 'Sync primary subtitle timing to secondary if languages match' }
+  ],
+
+  anilist: [
+    { key: 'anilist_enabled', label: 'Enable AniList', type: 'checkbox' },
+    { key: 'anilist_token', label: 'AniList Token', type: 'password' },
+    { key: 'anilist_update_thresh_percent', label: 'AniList Threshold', type: 'number', desc: '80-100' },
+    { key: 'anilist_show_notifications', label: 'AniList OSD', type: 'checkbox' },
+
+    { type: 'header', label: 'Keybindings' },
+    { key: 'key_anilist_auth', label: 'AniList Auth', type: 'keybind' }
+  ],
+
+  updater: [
+    { key: 'updater_enabled', label: 'Enable Updater', type: 'checkbox' },
+    { key: 'updater_check_on_startup', label: 'Check for Updates', type: 'checkbox' },
+    { key: 'updater_use_source', label: 'Update from Source', type: 'checkbox' },
+
+    { type: 'header', label: 'Keybindings' },
+    { key: 'key_update', label: 'Update', type: 'keybind' }
+  ],
+
+  mpv: [
+    { key: 'osd_messages', label: 'Show OSD Messages', type: 'checkbox' }
+  ]
+};
+
+function renderFields() {
+  Object.keys(fieldConfigs).forEach(section => {
+    const container = document.getElementById(`fields-${section}`);
+    if (!container) return;
+    
+    container.innerHTML = '';
+    fieldConfigs[section].forEach(conf => {
+      const fieldEl = document.createElement('div');
+      fieldEl.className = 'field';
+      
+      const val = currentConfig[conf.key];
+      
+      if (conf.type === 'header') {
+        fieldEl.className = 'field-section-header';
+        fieldEl.textContent = conf.label;
+      } else if (conf.type === 'profiles-manager') {
+        fieldEl.className = 'profiles-manager-container';
+        fieldEl.innerHTML = `
+          <div id="profile-list" class="profile-list"></div>
+          <div class="profile-create">
+            <label for="new-profile-name">Create profile</label>
+            <div class="input-row">
+              <input id="new-profile-name" type="text" spellcheck="false">
+              <button id="btn-create-profile" class="btn-primary">Create</button>
+            </div>
+            <p class="hint">
+              Creates <code>script-opts/yomipv_<em>&lt;name&gt;</em>.conf</code> as a copy of the current config.
+            </p>
+          </div>
+        `;
+        
+        // Wait for DOM attachment
+        setTimeout(() => {
+          const refreshBtn = document.getElementById('btn-refresh-profiles');
+          const createBtn = document.getElementById('btn-create-profile');
+          if (refreshBtn) refreshBtn.onclick = () => ipcRenderer.send('profile-list-request');
+          if (createBtn) {
+            createBtn.onclick = () => {
+              const input = document.getElementById('new-profile-name');
+              const rawName = input.value.trim();
+              const name = rawName.toLowerCase().replace(/[^a-z0-9_-]/g, '');
+              if (!rawName) { showToast('Please enter a name'); return; }
+              if (!name) { showToast('Invalid name'); return; }
+              ipcRenderer.send('profile-create', name);
+              input.value = '';
+              showToast(`Creating profile: ${name}`);
+            };
+          }
+          renderProfiles();
+        }, 0);
+      } else if (conf.type === 'checkbox') {
+        fieldEl.innerHTML = `
+          <div class="field-label"></div>
+          <div class="checkbox-container">
+            <input type="checkbox" id="field-${conf.key}">
+          </div>
+          <div class="field-desc"></div>
+        `;
+        const input = fieldEl.querySelector('input');
+        input.checked = !!val;
+        input.onchange = (e) => updateSetting(conf.key, e.target.checked);
+        fieldEl.querySelector('.field-label').textContent = conf.label;
+        if (conf.desc) fieldEl.querySelector('.field-desc').textContent = conf.desc;
+        else fieldEl.querySelector('.field-desc').remove();
+      } else if (conf.type === 'select') {
+        fieldEl.innerHTML = `
+          <div class="field-label"></div>
+          <div class="field-input-row">
+            <select id="field-${conf.key}"></select>
+          </div>
+          <div class="field-desc"></div>
+        `;
+        const select = fieldEl.querySelector('select');
+        conf.options.forEach(opt => {
+          const option = document.createElement('option');
+          option.value = opt.value;
+          option.textContent = opt.label;
+          select.appendChild(option);
+        });
+        select.value = val;
+        select.onchange = (e) => updateSetting(conf.key, e.target.value);
+        fieldEl.querySelector('.field-label').textContent = conf.label;
+        if (conf.desc) fieldEl.querySelector('.field-desc').textContent = conf.desc;
+        else fieldEl.querySelector('.field-desc').remove();
+      } else if (conf.type === 'keybind') {
+        fieldEl.innerHTML = `
+          <div class="field-label"></div>
+          <div class="field-input-row">
+            <input type="text" class="keybind-input" id="field-${conf.key}" readonly placeholder="Click to record...">
+          </div>
+          <div class="field-desc"></div>
+        `;
+        const input = fieldEl.querySelector('input');
+        input.value = (val !== undefined && val !== null) ? val : '';
+        
+        input.onclick = () => {
+          if (input.classList.contains('recording')) return;
+          
+          input.value = 'Press key...';
+          input.classList.add('recording');
+          
+          const onKeydown = (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            
+            let key = e.key;
+            if (['Control', 'Shift', 'Alt', 'Meta'].includes(key)) return;
+
+            const keyMap = {
+              'ArrowUp': 'UP',
+              'ArrowDown': 'DOWN',
+              'ArrowLeft': 'LEFT',
+              'ArrowRight': 'RIGHT',
+              'Enter': 'ENTER',
+              'Escape': 'ESC',
+              ' ': 'SPACE',
+              'Backspace': 'BS',
+              'Delete': 'DEL',
+              'Insert': 'INS',
+              'Home': 'HOME',
+              'End': 'END',
+              'PageUp': 'PGUP',
+              'PageDown': 'PGDWN',
+              'Tab': 'TAB'
+            };
+            
+            if (keyMap[key]) key = keyMap[key];
+            else if (key.length > 1) key = key.toUpperCase();
+
+            let mods = [];
+            if (e.ctrlKey) mods.push('Ctrl');
+            if (e.altKey) mods.push('Alt');
+            if (e.shiftKey) mods.push('Shift');
+            
+            const combo = mods.length > 0 ? mods.join('+') + '+' + key : key;
+            
+            input.value = combo;
+            input.classList.remove('recording');
+            updateSetting(conf.key, combo);
+            window.removeEventListener('keydown', onKeydown, true);
+          };
+          
+          window.addEventListener('keydown', onKeydown, true);
+        };
+
+        fieldEl.querySelector('.field-label').textContent = conf.label;
+        if (conf.desc) fieldEl.querySelector('.field-desc').textContent = conf.desc;
+        else fieldEl.querySelector('.field-desc').remove();
+      } else {
+        fieldEl.innerHTML = `
+          <div class="field-label"></div>
+          <div class="field-input-row">
+            <input type="${conf.type}" id="field-${conf.key}" spellcheck="false">
+          </div>
+          <div class="field-desc"></div>
+        `;
+        const input = fieldEl.querySelector('input');
+        input.value = (val !== undefined && val !== null) ? val : '';
+        input.onblur = (e) => updateSetting(conf.key, e.target.value);
+        fieldEl.querySelector('.field-label').textContent = conf.label;
+        if (conf.desc) fieldEl.querySelector('.field-desc').textContent = conf.desc;
+        else fieldEl.querySelector('.field-desc').remove();
+      }
+      
+      container.appendChild(fieldEl);
+    });
+  });
+}
+
+function updateSetting(key, val) {
+  ipcRenderer.send('settings-set', { key, value: val });
+  currentConfig[key] = val;
+  showToast('Setting saved');
+}
+
+// Profile logic
+function renderProfiles(profiles) {
+  if (profiles) lastProfileList = profiles;
+  const container = document.getElementById('profile-list');
+  if (!container) return;
+  container.innerHTML = '';
+  
+  const profilesToRender = lastProfileList;
+  const baseCard = document.createElement('div');
+  baseCard.className = `profile-card ${activeProfile === 'default' ? 'active' : ''}`;
+  baseCard.innerHTML = `
+    <div class="profile-name">Default (yomipv.conf)</div>
+    <div class="profile-actions">
+      <button class="btn-primary btn-switch" ${activeProfile === 'default' ? 'disabled' : ''}>Switch</button>
+    </div>
+  `;
+  baseCard.querySelector('.btn-switch').onclick = () => switchProfile('default');
+  container.appendChild(baseCard);
+  
+  // External profiles
+  profilesToRender.forEach(name => {
+    const card = document.createElement('div');
+    card.className = `profile-card ${activeProfile === name ? 'active' : ''}`;
+    card.innerHTML = `
+      <div class="profile-name">${name}</div>
+      <div class="profile-actions">
+        <button class="btn-primary btn-switch" ${activeProfile === name ? 'disabled' : ''}>Switch</button>
+        <button class="btn-danger btn-delete">Delete</button>
+      </div>
+    `;
+    card.querySelector('.btn-switch').onclick = () => switchProfile(name);
+    card.querySelector('.btn-delete').onclick = () => deleteProfile(name);
+    container.appendChild(card);
+  });
+}
+
+function switchProfile(name) {
+  ipcRenderer.send('profile-switch', name);
+  showToast(`Switching to profile: ${name}`);
+}
+
+function deleteProfile(name) {
+  if (confirm(`Delete profile "${name}"? This will remove yomipv_${name}.conf.`)) {
+    ipcRenderer.send('profile-delete', name);
+  }
+}
+
+
+// IPC listeners
+ipcRenderer.on('settings-data', (event, data) => {
+  if (data && data.config) {
+    currentConfig = data.config;
+    activeProfile = data.config.current_profile || 'default';
+    renderFields();
+    renderProfiles(); // Re-render profiles to update highlight
+  }
+});
+
+ipcRenderer.on('profile-list', (event, profiles) => {
+  renderProfiles(profiles);
+});
+
+// Initialization
+renderFields();
+ipcRenderer.send('settings-window-ready');
+ipcRenderer.send('profile-list-request');

--- a/scripts/yomipv/main.lua
+++ b/scripts/yomipv/main.lua
@@ -10,6 +10,7 @@ local script_dir = mp.get_script_directory()
 package.path = script_dir .. "/?.lua;" .. script_dir .. "/?/init.lua;" .. package.path
 
 local config = require("options")
+local Platform = require("lib.platform")
 local Curl = require("lib.curl")
 local Player = require("lib.player")
 local Yomitan = require("api.yomitan")
@@ -33,6 +34,7 @@ local Audio = require("media.audio")
 local Launcher = require("lib.launcher")
 local Updater = require("lib.updater")
 local MouseHandler = require("interface.mouse_handler")
+local Profiles = require("lib.profiles")
 
 msg.info("Yomipv v" .. yomipv_version .. ": Initializing...")
 
@@ -101,6 +103,69 @@ mp.add_hook("on_pre_shutdown", 50, function()
 	Launcher.shutdown_lookup_app()
 end)
 
+local function send_to_lookup_app(endpoint, data)
+	local utils = require("mp.utils")
+	local json = utils.format_json(data)
+	local curl_cmd = Platform.get_curl_cmd()
+
+	mp.command_native_async({
+		name = "subprocess",
+		playback_only = false,
+		args = {
+			curl_cmd,
+			"-s",
+			"-X",
+			"POST",
+			"-H",
+			"Content-Type: application/json",
+			"-d",
+			json,
+			"--connect-timeout",
+			"1",
+			"http://127.0.0.1:19634/" .. endpoint,
+		},
+	}, function(success, result, err)
+		if not success or (result and result.status ~= 0) then
+			msg.warn(string.format("Lookup App IPC failed (%s): %s", endpoint, err or (result and result.status or "unknown")))
+		end
+	end)
+end
+
+local function get_clean_config()
+	local clean = {}
+	for k, v in pairs(config) do
+		if type(v) ~= "function" and k ~= "defaults" then
+			clean[k] = v
+		end
+	end
+	return clean
+end
+
+-- Settings and profiles communication
+mp.register_script_message("yomipv-get-settings", function()
+	send_to_lookup_app("settings-data", { config = get_clean_config() })
+end)
+
+mp.register_script_message("yomipv-set-setting", function(key, val)
+	local default_val = config.defaults[key]
+	if default_val ~= nil then
+		local coerced = val
+		if type(default_val) == "boolean" then
+			coerced = val == "true" or val == "yes"
+		elseif type(default_val) == "number" then
+			coerced = tonumber(val) or default_val
+		end
+		config[key] = coerced
+		config.save(key, coerced)
+		Player.notify("Setting updated: " .. key, "info", 1)
+	end
+end)
+
+mp.register_script_message("yomipv-list-profiles", function()
+	local list = Profiles.list()
+	send_to_lookup_app("profile-list-data", list)
+end)
+
 -- Process selection events and coordinate dictionary expansion
 mp.register_script_message("yomipv-active-entry", function(exp, red)
 	handler:set_active_entry(exp, red)
@@ -121,114 +186,119 @@ mp.register_script_message("yomipv-dictionary-selected", function(text)
 	handler:set_selected_dictionary(text)
 end)
 
--- Core user actions for content export and colorization
-mp.add_key_binding(config.key_open_selector, "yomipv-export", function()
-	if handler then handler:start_export(history) end
-end)
-
-mp.add_key_binding(config.key_toggle_colorizer, "yomipv-toggle-colorizer", function()
-	handler:toggle_colorizer()
-end)
-
-mp.add_key_binding(config.key_append_mode, "yomipv-toggle-append-mode", function()
-	handler:toggle_mark_range()
-end)
-
-if config.selector_show_history then
-	mp.add_key_binding(config.key_toggle_history, "yomipv-toggle-history", function()
-		if history.active then history:close() else history:open() end
-	end)
-end
-
--- Primary and secondary subtitle navigation
-if config.key_sub_seek_next ~= "" then
-	mp.add_key_binding(config.key_sub_seek_next, "yomipv-sub-seek-next", function()
-		mp.commandv("sub-seek", "1")
-	end)
-end
-
-if config.key_sub_seek_prev ~= "" then
-	mp.add_key_binding(config.key_sub_seek_prev, "yomipv-sub-seek-prev", function()
-		mp.commandv("sub-seek", "-1")
-	end)
-end
-
-if config.key_secondary_sub_next ~= "" then
-	mp.add_key_binding(config.key_secondary_sub_next, "yomipv-secondary-sub-next", function()
-		SecondarySid.cycle_track(1)
-	end)
-end
-
-if config.key_secondary_sub_prev ~= "" then
-	mp.add_key_binding(config.key_secondary_sub_prev, "yomipv-secondary-sub-prev", function()
-		SecondarySid.cycle_track(-1)
-	end)
-end
-
--- Update management and database background tasks
-if config.key_update ~= "" then
-	mp.add_key_binding(config.key_update, "yomipv-update", function()
-		Updater.launch(config)
-	end)
-end
-
-if config.key_build_ankidb ~= "" then
-	mp.add_key_binding(config.key_build_ankidb, "yomipv-build-anki-db", function()
-		AnkiDBBuilder.new(config, anki):build_with_notification(handler)
-	end)
-end
-
--- Manual timing overrides for card creation
-if config.key_set_timing_start ~= "" then
-	mp.add_key_binding(config.key_set_timing_start, "yomipv-set-timing-start", function()
-		handler:set_manual_start()
-	end)
-end
-
-if config.key_set_timing_end ~= "" then
-	mp.add_key_binding(config.key_set_timing_end, "yomipv-set-timing-end", function()
-		handler:set_manual_end()
-	end)
-end
-
-if config.key_clear_timings ~= "" then
-	mp.add_key_binding(config.key_clear_timings, "yomipv-clear-timings", function()
-		handler:clear_manual_timings()
-	end)
-end
-
--- Property overrides and UI feature toggles
-if config.key_toggle_picture_animated ~= "" then
-	mp.add_key_binding(config.key_toggle_picture_animated, "yomipv-toggle-picture-animated", function()
-		config.picture_animated = not config.picture_animated
-		config.save("picture_animated", config.picture_animated)
-		Player.notify("Animated pictures: " .. (config.picture_animated and "Enabled" or "Disabled"), "info")
-		if history and history.active then history:update(true) end
-	end)
-end
-
-if config.key_toggle_mora_navigation ~= "" then
-	mp.add_key_binding(config.key_toggle_mora_navigation, "yomipv-toggle-mora-navigation", function()
-		config.selector_mora_navigation = not config.selector_mora_navigation
-		config.save("selector_mora_navigation", config.selector_mora_navigation)
-		Player.notify("Mora navigation: " .. (config.selector_mora_navigation and "Enabled" or "Disabled"), "info")
-		if Selector.active then
-			Selector.style.selector_mora_navigation = config.selector_mora_navigation
-			Selector:render()
-		end
-	end)
-end
-
-if config.key_toggle_selector_trigger_on_mouse_move ~= "" then
-	mp.add_key_binding(config.key_toggle_selector_trigger_on_mouse_move, "yomipv-toggle-selector-trigger-on-mouse-move",
-		function()
+local function register_keybindings()
+	local bindings = {
+		{ config.key_open_settings, "yomipv-open-settings", function() send_to_lookup_app("settings-open", {}) end },
+		{ config.key_open_selector, "yomipv-export", function() if handler then handler:start_export(history) end end },
+		{ config.key_toggle_colorizer, "yomipv-toggle-colorizer", function() handler:toggle_colorizer() end },
+		{ config.key_append_mode, "yomipv-toggle-append-mode", function() handler:toggle_mark_range() end },
+		{ config.key_toggle_history, "yomipv-toggle-history", function()
+			if history.active then history:close() else history:open() end
+		end },
+		{ config.key_sub_seek_next, "yomipv-sub-seek-next", function() mp.commandv("sub-seek", "1") end },
+		{ config.key_sub_seek_prev, "yomipv-sub-seek-prev", function() mp.commandv("sub-seek", "-1") end },
+		{ config.key_secondary_sub_next, "yomipv-secondary-sub-next", function() SecondarySid.cycle_track(1) end },
+		{ config.key_secondary_sub_prev, "yomipv-secondary-sub-prev", function() SecondarySid.cycle_track(-1) end },
+		{ config.key_update, "yomipv-update", function() Updater.launch(config) end },
+		{ config.key_build_ankidb, "yomipv-build-anki-db", function()
+			AnkiDBBuilder.new(config, anki):build_with_notification(handler)
+		end },
+		{ config.key_set_timing_start, "yomipv-set-timing-start", function() handler:set_manual_start() end },
+		{ config.key_set_timing_end, "yomipv-set-timing-end", function() handler:set_manual_end() end },
+		{ config.key_clear_timings, "yomipv-clear-timings", function() handler:clear_manual_timings() end },
+		{ config.key_toggle_picture_animated, "yomipv-toggle-picture-animated", function()
+			config.picture_animated = not config.picture_animated
+			config.save("picture_animated", config.picture_animated)
+			Player.notify("Animated pictures: " .. (config.picture_animated and "Enabled" or "Disabled"), "info")
+			if history and history.active then history:update(true) end
+		end },
+		{ config.key_toggle_mora_navigation, "yomipv-toggle-mora-navigation", function()
+			config.selector_mora_navigation = not config.selector_mora_navigation
+			config.save("selector_mora_navigation", config.selector_mora_navigation)
+			Player.notify("Mora navigation: " .. (config.selector_mora_navigation and "Enabled" or "Disabled"), "info")
+			if Selector.active then
+				Selector.style.selector_mora_navigation = config.selector_mora_navigation
+				Selector:render()
+			end
+		end },
+		{ config.key_toggle_selector_trigger_on_mouse_move, "yomipv-toggle-selector-trigger-on-mouse-move", function()
 			config.selector_trigger_on_mouse_move = not config.selector_trigger_on_mouse_move
 			config.save("selector_trigger_on_mouse_move", config.selector_trigger_on_mouse_move)
 			local status = config.selector_trigger_on_mouse_move and "Enabled" or "Disabled"
 			Player.notify("Selector mouse trigger: " .. status, "info")
+		end },
+		{ config.key_cycle_profile, "yomipv-cycle-profile", function()
+			local new_name, err = Profiles.cycle(config, config.defaults)
+			if new_name then
+				config.save("current_profile", new_name)
+				handler:sync_state()
+				register_keybindings()
+				Player.notify("Profile: " .. new_name, "info", 3)
+				send_to_lookup_app("settings-data", { config = get_clean_config() })
+			else
+				Player.notify(err or "Profile switch failed", "warn", 3)
+			end
+		end }
+	}
+
+	for _, b in ipairs(bindings) do
+		local key, name, fn = b[1], b[2], b[3]
+		if key and key ~= "" then
+			mp.add_key_binding(key, name, fn)
+		else
+			mp.remove_key_binding(name)
 		end
-	)
+	end
 end
+
+mp.register_script_message("yomipv-switch-profile", function(name)
+	local ok, err = Profiles.load(name, config, config.defaults)
+
+	if ok then
+		config.save("current_profile", name)
+		handler:sync_state()
+		register_keybindings()
+		Player.notify("Profile: " .. name, "success", 2)
+		send_to_lookup_app("settings-data", { config = get_clean_config() })
+	else
+		Player.notify(err or "Failed to switch profile", "error", 3)
+	end
+end)
+
+mp.register_script_message("yomipv-create-profile", function(name)
+	local ok, err = Profiles.create(name, config)
+	if ok then
+		Player.notify("Profile created: " .. name, "success", 2)
+		local list = Profiles.list()
+		send_to_lookup_app("profile-list-data", list)
+	else
+		Player.notify(err or "Failed to create profile", "error", 3)
+	end
+end)
+
+mp.register_script_message("yomipv-delete-profile", function(name)
+	local ok, err = Profiles.delete(name)
+	if ok then
+		Player.notify("Profile deleted: " .. name, "info", 2)
+		local list = Profiles.list()
+		send_to_lookup_app("profile-list-data", list)
+	else
+		Player.notify(err or "Failed to delete profile", "error", 3)
+	end
+end)
+
+-- Startup profile restoration
+if config.current_profile and config.current_profile ~= "default" then
+	local ok, err = Profiles.load(config.current_profile, config, config.defaults)
+	if ok then
+		handler:sync_state()
+	else
+		msg.warn("Startup profile load failed: " .. tostring(err))
+		config.current_profile = "default"
+	end
+end
+
+register_keybindings()
 
 msg.info("Yomipv v" .. yomipv_version .. ": Initialized")
 Player.notify("Yomipv v" .. yomipv_version .. " loaded", "success", 2)

--- a/scripts/yomipv/options.lua
+++ b/scripts/yomipv/options.lua
@@ -283,18 +283,34 @@ local default_options = {
 
 	--[[ MPV Settings ]]
 
-
 	osd_messages = true, -- Show OSD messages
+
+	--[[ Profile settings ]]
+
+	current_profile = "default", -- Active profile name
+	key_cycle_profile = "Ctrl+p", -- Cycle through available profiles
+	key_open_settings = "Ctrl+i", -- Open settings menu
 }
 
 local options = default_options
 local mp_options = require("mp.options")
 mp_options.read_options(options, "yomipv")
 
+-- Snapshot defaults for type-coercion
+options.defaults = {}
+for k, v in pairs(default_options) do
+	options.defaults[k] = v
+end
+
 function options.save(key, value)
-	local path = mp.find_config_file("script-opts/yomipv.conf")
+	local filename = "yomipv.conf"
+	if key ~= "current_profile" and options.current_profile and options.current_profile ~= "default" then
+		filename = "yomipv_" .. options.current_profile .. ".conf"
+	end
+
+	local path = mp.find_config_file("script-opts/" .. filename)
 	if not path then
-		path = mp.command_native({ "expand-path", "~~/script-opts/yomipv.conf" })
+		path = mp.command_native({ "expand-path", "~~/script-opts/" .. filename })
 	end
 	if not path then
 		return false
@@ -323,6 +339,15 @@ function options.save(key, value)
 			for _, line in ipairs(lines) do
 				file:write(line .. "\n")
 			end
+			file:close()
+			return true
+		end
+	else
+		-- Append new key if it doesn't exist
+		file = io.open(path, "a")
+		if file then
+			local val_str = type(value) == "boolean" and (value and "yes" or "no") or tostring(value)
+			file:write(key .. "=" .. val_str .. "\n")
 			file:close()
 			return true
 		end


### PR DESCRIPTION
This adds a proper settings system to Yomipv, with a GUI and support for profiles so different media types don’t share the same config.

#### Settings UI

* **New GUI panel**: Added a grid-based settings UI (default `Ctrl+i`), so most things can be configured without touching config files.
* **Keybind editing**: You can now record keybinds directly from the UI.

#### Profiles (#28)

* **Profile support**: Create, switch, and delete profiles (anime, drama). 
* **Per-profile configs**: Each profile writes to its own file (`yomipv_anime.conf`, etc.).
* **Auto restore**: The last active profile is saved and restored on startup.