### PR TITLE
Improve colorizer, capture timing, and lookup app packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,19 @@ jobs:
         working-directory: scripts/yomipv/lookup-app
         run: npm install
         
-      - name: Build Windows Executable
+      - name: Build Windows Unpacked App
         working-directory: scripts/yomipv/lookup-app
-        run: npx electron-builder --win --x64 --publish never
+        run: npx electron-builder --win dir --x64 --publish never
+
+      - name: Verify Windows Unpacked App
+        shell: bash
+        run: test -f scripts/yomipv/lookup-app/dist/win-unpacked/YomipvLookup.exe
         
       - name: Upload Windows Asset
         uses: actions/upload-artifact@v4
         with:
           name: yomipv-lookup-windows
-          path: scripts/yomipv/lookup-app/dist/*.exe
+          path: scripts/yomipv/lookup-app/dist/win-unpacked
 
   build-linux:
     runs-on: ubuntu-latest
@@ -70,17 +74,20 @@ jobs:
         working-directory: scripts/yomipv/lookup-app
         run: npm install
         
-      - name: Build Linux Binaries
+      - name: Build Linux Unpacked App
         working-directory: scripts/yomipv/lookup-app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx electron-builder --linux --x64 --publish never
+        run: npx electron-builder --linux dir --x64 --publish never
+
+      - name: Verify Linux Unpacked App
+        run: test -x scripts/yomipv/lookup-app/dist/linux-unpacked/YomipvLookup
         
       - name: Upload Linux Asset
         uses: actions/upload-artifact@v4
         with:
           name: yomipv-lookup-linux
-          path: scripts/yomipv/lookup-app/dist/*.AppImage
+          path: scripts/yomipv/lookup-app/dist/linux-unpacked
 
   build-macos:
     runs-on: macos-latest
@@ -165,7 +172,12 @@ jobs:
           
           # Create Windows bundle
           cp -r common-bundle win-bundle
-          cp bin-win/*.exe win-bundle/scripts/yomipv/ || true
+          mkdir -p win-bundle/scripts/yomipv/YomipvLookup
+          if [ -d bin-win/win-unpacked ]; then
+            cp -r bin-win/win-unpacked/. win-bundle/scripts/yomipv/YomipvLookup/
+          else
+            cp -r bin-win/. win-bundle/scripts/yomipv/YomipvLookup/
+          fi
           cp yomipv-updater.ps1 yomipv-updater.bat win-bundle/ 2>/dev/null || true
           cd win-bundle
           zip -r ../win-yomipv-${{ github.ref_name }}.zip ./*
@@ -173,7 +185,13 @@ jobs:
           
           # Create Linux bundle
           cp -r common-bundle linux-bundle
-          cp bin-linux/*.AppImage linux-bundle/scripts/yomipv/ || true
+          mkdir -p linux-bundle/scripts/yomipv/YomipvLookup
+          if [ -d bin-linux/linux-unpacked ]; then
+            cp -r bin-linux/linux-unpacked/. linux-bundle/scripts/yomipv/YomipvLookup/
+          else
+            cp -r bin-linux/. linux-bundle/scripts/yomipv/YomipvLookup/
+          fi
+          chmod +x linux-bundle/scripts/yomipv/YomipvLookup/YomipvLookup
           cp yomipv-updater.sh linux-bundle/ 2>/dev/null || true
           cd linux-bundle
           zip -r ../linux-yomipv-${{ github.ref_name }}.zip ./*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+tests/
+
+# Lookup app dependencies and build output
+scripts/yomipv/lookup-app/node_modules/
+scripts/yomipv/lookup-app/dist/
+scripts/yomipv/lookup-app/out/

--- a/docs/colorizer.md
+++ b/docs/colorizer.md
@@ -30,6 +30,12 @@ selector_colorize_words=yes
 selector_colorize_underline=no
 ```
 
+### Subtitle Language
+
+The colorizer only replaces mpv subtitles when the primary subtitle track is Japanese. It uses the track language tag when available (`ja`, `jp`, `jpn`, `japanese`, or `日本語`). If the track has no language tag, it falls back to detecting Japanese characters in the subtitle text
+
+For non-Japanese primary subtitle tracks, normal mpv subtitles stay visible and the colorizer overlay is not shown
+
 ### Synchronization
 
 The colorizer relies on a local snapshot of your Anki database (`anki_words.json`) for performance. You must manually trigger a rebuild of this database to sync your latest Anki progress

--- a/docs/colorizer.md
+++ b/docs/colorizer.md
@@ -42,9 +42,10 @@ Pressing this key will fetch your current card intervals and statuses from Anki 
 
 1. **AnkiConnect**: Ensure Anki is open with the AnkiConnect add-on installed and configured
 2. **Database Build**: You must press the `B` key at least once to generate the initial database
-3. **Fields**: Ensure `ankidb_fields` in your configuration correctly maps to the fields in your Anki note types that contain the Japanese expression
+3. **Fields**: Ensure `ankidb_word_fields` maps to the fields in your Anki note types that contain the Japanese expression. Optionally set `ankidb_reading_fields` to fields that contain readings, which makes kana matching more accurate
 
 ```ini
 # Example field mapping for database building
-ankidb_fields=word Word expression Expression
+ankidb_word_fields=word Word expression Expression
+ankidb_reading_fields=reading Reading "Word Reading"
 ```

--- a/script-opts/yomipv.conf
+++ b/script-opts/yomipv.conf
@@ -12,7 +12,9 @@ ankiconnect_url=127.0.0.1:8765
 ankiconnect_api_key=
 
 # Anki DB build settings
-ankidb_fields=word Word expression Expression
+# Quote field names that contain spaces
+ankidb_word_fields=word Word expression Expression
+ankidb_reading_fields=reading Reading "Word Reading"
 
 # Deck and Note type
 deck=Senren

--- a/scripts/yomipv/api/anilist.lua
+++ b/scripts/yomipv/api/anilist.lua
@@ -135,6 +135,49 @@ function Anilist:update_episode(media_id, episode_num, callback)
 	end, { headers = headers })
 end
 
+local function trim(text)
+	if type(text) ~= "string" then return "" end
+	return text:gsub("^[ \t\n\r]+", ""):gsub("[ \t\n\r]+$", "")
+end
+
+local function add_unique(list, seen, value)
+	value = trim(value)
+	if value ~= "" and not seen[value] then
+		table.insert(list, value)
+		seen[value] = true
+	end
+end
+
+local function get_title_variants(title)
+	local variants = {}
+	local seen = {}
+
+	add_unique(variants, seen, title)
+
+	local split_source = tostring(title or "") .. " - "
+	for part in split_source:gmatch("(.-)%s+%-%s+") do
+		add_unique(variants, seen, part)
+	end
+
+	return variants
+end
+
+local function get_search_queries(title, season_n)
+	local queries = {}
+	local seen = {}
+
+	for _, variant in ipairs(get_title_variants(title)) do
+		if season_n and season_n > 1 then
+			add_unique(queries, seen, string.format("%s Season %d", variant, season_n))
+			add_unique(queries, seen, string.format("%s %d", variant, season_n))
+		else
+			add_unique(queries, seen, variant)
+		end
+	end
+
+	return queries
+end
+
 function Anilist:check_and_update(title, season_num, episode_num, callback)
 	local season_n = tonumber(season_num)
 
@@ -144,15 +187,7 @@ function Anilist:check_and_update(title, season_num, episode_num, callback)
 		return
 	end
 
-	local primary_query = title
-	local fallback_query = nil
-	if season_n and season_n > 1 then
-		-- Try "Season N" first; bare number suffix is the fallback
-		primary_query = string.format("%s Season %d", title, season_n)
-		fallback_query = string.format("%s %d", title, season_n)
-	end
-
-	msg.info(string.format("Looking up AniList for '%s' to update Episode %s", primary_query, tostring(episode_num)))
+	local search_queries = get_search_queries(title, season_n)
 
 	local function process_media(media, target_ep)
 		if not media.episodes or target_ep <= media.episodes then
@@ -200,25 +235,24 @@ function Anilist:check_and_update(title, season_num, episode_num, callback)
 		end
 	end
 
-	self:search_anime_by_title(primary_query, function(search_success, media_or_err)
-		if search_success then
-			process_media(media_or_err, episode_num)
+	local function try_search(index, last_err)
+		local query = search_queries[index]
+		if not query then
+			if callback then callback(false, last_err or "No anime found") end
 			return
 		end
-		-- Primary query failed; retry with bare number suffix if available
-		if fallback_query then
-			msg.info(string.format("Retrying with fallback query '%s'", fallback_query))
-			self:search_anime_by_title(fallback_query, function(fb_success, fb_media_or_err)
-				if fb_success then
-					process_media(fb_media_or_err, episode_num)
-				else
-					if callback then callback(false, fb_media_or_err) end
-				end
-			end)
-		else
-			if callback then callback(false, media_or_err) end
-		end
-	end)
+
+		msg.info(string.format("Looking up AniList for '%s' to update Episode %s", query, tostring(episode_num)))
+		self:search_anime_by_title(query, function(search_success, media_or_err)
+			if search_success then
+				process_media(media_or_err, episode_num)
+			else
+				try_search(index + 1, media_or_err)
+			end
+		end)
+	end
+
+	try_search(1)
 end
 
 return Anilist

--- a/scripts/yomipv/api/match_sort.lua
+++ b/scripts/yomipv/api/match_sort.lua
@@ -1,5 +1,5 @@
 --[[
-  Matched-length sorting helpers for dictionary entry ranking.
+  Matched-length sorting helpers for dictionary entry ranking
   Algorithm must stay in sync with lookup-app/match-sort.js
 ]]
 
@@ -60,8 +60,8 @@ function M.prefix_match_len(a, b)
 	return i
 end
 
---- Compute match score: max prefix match of term against expr and reading (kana-normalized).
---- Compares against both expression (handles kanji lookup) and reading (handles kana lookup).
+--- Compute match score: max prefix match of term against expr and reading (kana-normalized)
+--- Compares against both expression (handles kanji lookup) and reading (handles kana lookup)
 ---@param term_cps integer[] pre-computed normalized codepoints of the lookup term
 ---@param expr string
 ---@param reading string

--- a/scripts/yomipv/capture/monitor.lua
+++ b/scripts/yomipv/capture/monitor.lua
@@ -6,6 +6,7 @@ local msg = require("mp.msg")
 
 local Monitor = {
 	history = {},
+	raw_history = {},
 	recorded = {},
 	appending = false,
 	max_history = 200,
@@ -44,6 +45,18 @@ function Monitor.get_history(count)
 	return Monitor.history
 end
 
+function Monitor.get_raw_history(count)
+	if count and count > 0 then
+		local start_idx = math.max(1, #Monitor.raw_history - count + 1)
+		local result = {}
+		for i = start_idx, #Monitor.raw_history do
+			table.insert(result, Monitor.raw_history[i])
+		end
+		return result
+	end
+	return Monitor.raw_history
+end
+
 -- Normalize text for comparison
 local function normalize(s)
 	if not s or s == "" then
@@ -53,6 +66,83 @@ local function normalize(s)
 	local cleaned = s:gsub("{[^}]-}", ""):gsub("\\N", " "):gsub("\\n", " "):gsub("\\h", " ")
 	cleaned = StringOps.clean_text(cleaned, false)
 	return cleaned:lower():gsub("%s+", " ")
+end
+
+local function append_unique_secondary(entry, secondary)
+	if secondary == "" then
+		return false
+	end
+
+	if (entry.secondary_sid or "") == "" then
+		entry.secondary_sid = secondary
+		return true
+	end
+
+	local existing_lines = {}
+	for line in entry.secondary_sid:gmatch("[^\r\n]+") do
+		local normalized = normalize(line)
+		if normalized ~= "" then
+			existing_lines[normalized] = true
+		end
+	end
+
+	local to_append = {}
+	for line in secondary:gmatch("[^\r\n]+") do
+		local normalized = normalize(line)
+		if normalized ~= "" and not existing_lines[normalized] then
+			table.insert(to_append, line)
+			existing_lines[normalized] = true
+		end
+	end
+
+	if #to_append == 0 then
+		return false
+	end
+
+	entry.secondary_sid = entry.secondary_sid .. "\n" .. table.concat(to_append, "\n")
+	return true
+end
+
+local function make_entry(primary, secondary, subtitle)
+	return {
+		primary_sid = primary,
+		secondary_sid = secondary,
+		start = subtitle.start or 0,
+		["end"] = subtitle["end"] or 0,
+		delay = subtitle.delay or 0,
+		secondary_start = subtitle.secondary_start or 0,
+		secondary_end = subtitle.secondary_end or 0,
+		secondary_delay = subtitle.secondary_delay or 0,
+		timestamp = mp.get_time(),
+	}
+end
+
+local function add_to_raw_history(primary, secondary, subtitle)
+	local last = Monitor.raw_history[#Monitor.raw_history]
+	if last
+		and math.abs((last.start or 0) - (subtitle.start or 0)) < 0.1
+		and normalize(last.primary_sid) == normalize(primary) then
+		if secondary ~= "" then
+			last.secondary_sid = secondary
+			last.secondary_start = subtitle.secondary_start or last.secondary_start
+			last.secondary_end = subtitle.secondary_end or last.secondary_end
+			last.secondary_delay = subtitle.secondary_delay or last.secondary_delay
+		end
+		last["end"] = subtitle["end"] or last["end"]
+		return
+	end
+
+	table.insert(Monitor.raw_history, make_entry(primary, secondary, subtitle))
+	table.sort(Monitor.raw_history, function(a, b)
+		if math.abs(a.start - b.start) < 0.05 then
+			return a.timestamp < b.timestamp
+		end
+		return a.start < b.start
+	end)
+
+	if Monitor.max_history > 0 and #Monitor.raw_history > Monitor.max_history then
+		table.remove(Monitor.raw_history, 1)
+	end
 end
 
 -- Get synchronized history
@@ -146,30 +236,15 @@ function Monitor.add_to_history(subtitle)
 		end
 	end
 
+	add_to_raw_history(primary, secondary, subtitle)
+
 	-- Update existing secondary text
 	if overlap_entry then
 		local norm_overlap = normalize(overlap_entry.primary_sid)
 		local norm_new = normalize(primary)
 		if norm_overlap == norm_new or norm_overlap:find(norm_new, 1, true) then
-			if secondary ~= "" then
-				local norm_existing_sec = normalize(overlap_entry.secondary_sid)
-				local norm_new_sec = normalize(secondary)
-
-				-- Append unique segments
-				if norm_existing_sec == "" then
-					overlap_entry.secondary_sid = secondary
-				elseif not norm_existing_sec:find(norm_new_sec, 1, true) then
-					local to_append = ""
-					for sub_line in secondary:gmatch("[^\r\n]+") do
-						if not norm_existing_sec:find(normalize(sub_line), 1, true) then
-							to_append = to_append .. "\n" .. sub_line
-						end
-					end
-					overlap_entry.secondary_sid = overlap_entry.secondary_sid .. to_append
-					-- Extend duration
-					overlap_entry.secondary_end =
-						math.max(overlap_entry.secondary_end or 0, subtitle.secondary_end or 0)
-				end
+			if append_unique_secondary(overlap_entry, secondary) then
+				overlap_entry.secondary_end = math.max(overlap_entry.secondary_end or 0, subtitle.secondary_end or 0)
 			end
 			return
 		end
@@ -222,15 +297,9 @@ function Monitor.add_to_history(subtitle)
 						previous_entry.primary_sid = previous_entry.primary_sid .. "\n" .. primary
 					end
 
-					local to_append = ""
-					local norm_existing_sec = normalize(previous_entry.secondary_sid)
-					for sub_line in secondary:gmatch("[^\r\n]+") do
-						if not norm_existing_sec:find(normalize(sub_line), 1, true) then
-							to_append = to_append .. "\n" .. sub_line
-						end
+					if append_unique_secondary(previous_entry, secondary) then
+						previous_entry.secondary_end = math.max(previous_entry.secondary_end or 0, subtitle.secondary_end or 0)
 					end
-					previous_entry.secondary_sid = previous_entry.secondary_sid .. to_append
-					previous_entry.secondary_end = math.max(previous_entry.secondary_end or 0, subtitle.secondary_end or 0)
 
 					previous_entry["end"] = subtitle["end"] or previous_entry["end"]
 					return
@@ -252,17 +321,7 @@ function Monitor.add_to_history(subtitle)
 	end
 
 	-- Insert new entry
-	table.insert(Monitor.history, {
-		primary_sid = primary,
-		secondary_sid = secondary,
-		start = subtitle.start or 0,
-		["end"] = subtitle["end"] or 0,
-		delay = subtitle.delay or 0,
-		secondary_start = subtitle.secondary_start or 0,
-		secondary_end = subtitle.secondary_end or 0,
-		secondary_delay = subtitle.secondary_delay or 0,
-		timestamp = mp.get_time(),
-	})
+	table.insert(Monitor.history, make_entry(primary, secondary, subtitle))
 
 	-- Sort chronologically
 	table.sort(Monitor.history, function(a, b)
@@ -310,6 +369,7 @@ end
 -- Clear history entries
 function Monitor.clear_history()
 	Monitor.history = {}
+	Monitor.raw_history = {}
 	msg.info("History cleared")
 end
 

--- a/scripts/yomipv/export/anki_db_builder.lua
+++ b/scripts/yomipv/export/anki_db_builder.lua
@@ -10,6 +10,96 @@ local AnkiDBBuilder = {}
 
 local BATCH_SIZE = 50
 
+local function trim(text)
+	if type(text) ~= "string" then return nil end
+	local trimmed = text:gsub("^%s*(.-)%s*$", "%1")
+	return trimmed ~= "" and trimmed or nil
+end
+
+local function parse_field_list(raw)
+	local fields = {}
+	local text = trim(raw)
+	if not text then
+		return fields
+	end
+
+	local i = 1
+	while i <= #text do
+		while i <= #text and text:sub(i, i):match("%s") do
+			i = i + 1
+		end
+		if i > #text then
+			break
+		end
+
+		local char = text:sub(i, i)
+		if char == '"' or char == "'" then
+			local quote = char
+			local j = i + 1
+			while j <= #text and text:sub(j, j) ~= quote do
+				j = j + 1
+			end
+			local value = trim(text:sub(i + 1, j - 1))
+			if value then
+				table.insert(fields, value)
+			end
+			i = j + 1
+		else
+			local j = i
+			while j <= #text and not text:sub(j, j):match("%s") do
+				j = j + 1
+			end
+			local value = trim(text:sub(i, j - 1))
+			if value then
+				table.insert(fields, value)
+			end
+			i = j
+		end
+	end
+
+	return fields
+end
+
+local function get_word_fields(config)
+	return parse_field_list(config.ankidb_word_fields)
+end
+
+local function get_reading_fields(config)
+	local raw = config.ankidb_reading_fields
+	if trim(raw) then
+		return parse_field_list(raw)
+	end
+
+	local reading_field = trim(config.reading_field)
+	if reading_field then
+		return { reading_field }
+	end
+
+	return {}
+end
+
+local function add_reading(entry, reading)
+	if not reading then
+		return
+	end
+
+	if type(entry.reading) == "string" then
+		if entry.reading == reading then
+			return
+		end
+		entry.reading = { entry.reading, reading }
+	elseif type(entry.reading) == "table" then
+		for _, existing in ipairs(entry.reading) do
+			if existing == reading then
+				return
+			end
+		end
+		table.insert(entry.reading, reading)
+	else
+		entry.reading = { reading }
+	end
+end
+
 function AnkiDBBuilder.new(config, anki)
 	local obj = {
 		config = config,
@@ -20,10 +110,8 @@ function AnkiDBBuilder.new(config, anki)
 end
 
 function AnkiDBBuilder:build(callback)
-	local fields = {}
-	for field in self.config.ankidb_fields:gmatch("%S+") do
-		table.insert(fields, field)
-	end
+	local fields = get_word_fields(self.config)
+	local reading_fields = get_reading_fields(self.config)
 
 	if #fields == 0 then
 		return callback(false, "No fields configured for Anki database build")
@@ -54,7 +142,7 @@ function AnkiDBBuilder:build(callback)
 
 		local function process_cards_batch(index)
 			if index > total_cards then
-				return self:process_notes(note_data, fields, callback)
+				return self:process_notes(note_data, fields, reading_fields, callback)
 			end
 
 			local batch = {}
@@ -105,7 +193,7 @@ function AnkiDBBuilder:build(callback)
 	end)
 end
 
-function AnkiDBBuilder:process_notes(note_data, fields, callback)
+function AnkiDBBuilder:process_notes(note_data, fields, reading_fields, callback)
 	local note_ids = {}
 	for nid, _ in pairs(note_data) do
 		table.insert(note_ids, nid)
@@ -133,12 +221,23 @@ function AnkiDBBuilder:process_notes(note_data, fields, callback)
 				local nid = tonumber(note.noteId)
 				local note_fields = note.fields
 				local word = nil
+				local reading = nil
 
 				for _, f in ipairs(fields) do
 					local field_data = note_fields[f]
 					if field_data and field_data.value and field_data.value:gsub("%s+", "") ~= "" then
-						word = field_data.value:gsub("^%s*(.-)%s*$", "%1") -- Trim
+						word = trim(field_data.value)
 						break
+					end
+				end
+
+				for _, reading_field in ipairs(reading_fields) do
+					local field_data = note_fields[reading_field]
+					if field_data and field_data.value then
+						reading = trim(field_data.value)
+						if reading then
+							break
+						end
 					end
 				end
 
@@ -146,12 +245,14 @@ function AnkiDBBuilder:process_notes(note_data, fields, callback)
 					local res = note_data[nid]
 					if not word_data[word] then
 						word_data[word] = { interval = res.interval, state = res.state }
+						add_reading(word_data[word], reading)
 					else
 						local existing = word_data[word]
 						if res.interval > existing.interval then
 							existing.interval = res.interval
 							existing.state = res.state
 						end
+						add_reading(existing, reading)
 					end
 				end
 			end

--- a/scripts/yomipv/export/handler.lua
+++ b/scripts/yomipv/export/handler.lua
@@ -7,6 +7,7 @@ local StringOps = require("lib.string_ops")
 local Player = require("lib.player")
 local Counter = require("lib.counter")
 local Curl = require("lib.curl")
+local SubtitleLanguage = require("subtitle.language")
 
 local Handler = {}
 
@@ -869,6 +870,16 @@ function Handler:on_current_tokens_ready(tokens)
 		return
 	end
 
+	local subtitle_text = ""
+	for _, token in ipairs(tokens or {}) do
+		subtitle_text = subtitle_text .. (token.text or "")
+	end
+	if not SubtitleLanguage.is_primary_subtitle_japanese(subtitle_text) then
+		self.deps.selector:clear_passive()
+		mp.set_property("sub-visibility", "yes")
+		return
+	end
+
 	if self.deps.selector.active then
 		return
 	end
@@ -1153,23 +1164,29 @@ function Handler:new()
 end
 
 function Handler:init()
-	if self.config.colorizer_enabled then
+	if self.config.colorizer_enabled and SubtitleLanguage.is_primary_subtitle_japanese() then
 		mp.set_property("sub-visibility", "no")
 	end
 end
 
 function Handler:sync_state()
 	if self.config.colorizer_enabled then
-		mp.set_property("sub-visibility", "no")
 		local sub = self.deps.tracker.export_current_session()
 		if sub and sub.primary_sid and sub.primary_sid ~= "" then
 			local cleaned = StringOps.clean_subtitle(sub.primary_sid, true)
+			if not SubtitleLanguage.is_primary_subtitle_japanese(cleaned) then
+				mp.set_property("sub-visibility", "yes")
+				self.deps.selector:clear_passive()
+				return
+			end
+			mp.set_property("sub-visibility", "no")
 			self.deps.yomitan:tokenize(cleaned, function(tokens)
 				if self.config.colorizer_enabled then
 					self:on_current_tokens_ready(tokens)
 				end
 			end)
 		else
+			mp.set_property("sub-visibility", "yes")
 			self.deps.selector:clear_passive()
 		end
 	else

--- a/scripts/yomipv/export/handler.lua
+++ b/scripts/yomipv/export/handler.lua
@@ -196,6 +196,7 @@ function Handler:initialize_export_context(gui)
 	-- Reset per-session state
 	self.active_entry_expression = nil
 	self.active_entry_reading = nil
+	self.active_entry_original_len = nil
 	self.selected_dictionary = nil
 	self.last_selection = nil
 	self.last_selection_hint = nil
@@ -368,6 +369,10 @@ function Handler:handle_selector_result(context, selected_token)
 			self:on_current_tokens_ready(self.current_tokens)
 		end
 		return
+	end
+
+	if selected_token.capture_time_pos then
+		context.sub.picture_timestamp = selected_token.capture_time_pos
 	end
 
 	-- Clear manual timings to prevent stale OSD overlap
@@ -956,8 +961,10 @@ function Handler:build_selector_style(update_range_fn, was_paused, tokens)
 			self.selected_dictionary = nil
 			self.active_entry_expression = nil
 			self.active_entry_reading = nil
+			self.active_entry_original_len = nil
 			self.pending_lookup_term = data.term
 			self.pending_lookup_reading = data.reading
+			self.lookup_request_id = (self.lookup_request_id or 0) + 1
 
 			local custom_css = mp.command_native({ "expand-path", "~~/script-opts/yomipv.css" })
 			if require("mp.utils").file_info(custom_css) == nil then
@@ -974,6 +981,7 @@ function Handler:build_selector_style(update_range_fn, was_paused, tokens)
 				theme = self.config.lookup_theme,
 				customCss = custom_css,
 				isFocused = mp.get_property_bool("focused", true),
+				lookupRequestId = self.lookup_request_id,
 			}
 			local json_body = require("mp.utils").format_json(data_to_send)
 			local is_focused = mp.get_property_bool("focused", true)
@@ -983,6 +991,7 @@ function Handler:build_selector_style(update_range_fn, was_paused, tokens)
 		on_hide = function()
 			self.pending_lookup_term = nil
 			self.pending_lookup_reading = nil
+			self.lookup_request_id = (self.lookup_request_id or 0) + 1
 			Curl.post("http://127.0.0.1:19634/hide", "{}", function() end)
 		end,
 		word_colors = word_colors,
@@ -1105,9 +1114,18 @@ function Handler:sync_selection_hint(text)
 	self.last_selection_hint = text ~= "" and text or nil
 end
 
-function Handler:set_active_entry(expression, reading)
+function Handler:set_active_entry(expression, reading, original_len)
 	self.active_entry_expression = expression ~= "" and expression or nil
 	self.active_entry_reading = reading ~= "" and reading or nil
+	self.active_entry_original_len = tonumber(original_len) or 0
+end
+
+function Handler:is_current_lookup_request(request_id)
+	local numeric_id = tonumber(request_id)
+	if not numeric_id or numeric_id <= 0 then
+		return true
+	end
+	return numeric_id == self.lookup_request_id
 end
 
 function Handler:new()
@@ -1119,8 +1137,10 @@ function Handler:new()
 		last_selection_hint = nil,
 		active_entry_expression = nil,
 		active_entry_reading = nil,
+		active_entry_original_len = nil,
 		pending_lookup_term = nil,
 		pending_lookup_reading = nil,
+		lookup_request_id = 0,
 		manual_start = nil,
 		manual_end = nil,
 		timing_overlay = mp.create_osd_overlay("ass-events"),
@@ -1220,7 +1240,8 @@ function Handler:refresh_timing_overlay(start_override, end_override)
 end
 
 function Handler:apply_manual_range(context)
-	local history = self.deps.tracker.get_synchronized_history()
+	local history = self.deps.tracker.get_raw_history and self.deps.tracker.get_raw_history()
+		or self.deps.tracker.get_synchronized_history()
 	if not history or #history == 0 then
 		return
 	end
@@ -1229,9 +1250,14 @@ function Handler:apply_manual_range(context)
 	local effective_end = self.manual_end or context.sub["end"]
 
 	local collected = {}
+	local seen = {}
 	for _, entry in ipairs(history) do
 		if entry["end"] > effective_start and entry.start < effective_end then
-			table.insert(collected, entry)
+			local cleaned = StringOps.clean_subtitle(entry.primary_sid or "", true)
+			if cleaned ~= "" and not seen[cleaned] then
+				seen[cleaned] = true
+				table.insert(collected, entry)
+			end
 		end
 	end
 
@@ -1254,6 +1280,7 @@ function Handler:apply_manual_range(context)
 	context.sub.secondary_sid = combined_secondary
 	context.sub.start = effective_start
 	context.sub["end"] = effective_end
+	context.sub.is_manual_range = true
 	context.current_subtitle_text = combined_primary
 	context.first_subtitle = Collections.duplicate(collected[1])
 	context.last_subtitle = Collections.duplicate(collected[#collected])

--- a/scripts/yomipv/interface/selector/renderer.lua
+++ b/scripts/yomipv/interface/selector/renderer.lua
@@ -275,6 +275,7 @@ function Renderer.render(selector)
 								y = y_line + u_offset,
 								w = match_w,
 								color = seg.color,
+								term = seg.term,
 								is_colorizer = true,
 							})
 						end
@@ -302,6 +303,7 @@ function Renderer.render(selector)
 						y = y_line + u_offset,
 						w = underline_w,
 						color = color,
+						term = term,
 						is_colorizer = true,
 					})
 				end
@@ -425,20 +427,33 @@ function Renderer.render(selector)
 		end
 	end
 
-	-- Merge adjacent colorizer underlines sharing the same Y and color into one rect
+	-- Merge adjacent pieces of the same colorized term, but keep different
+	-- adjacent words visually separated even when they share the same color.
 	local merged = {}
 	for _, u in ipairs(underlines) do
 		if u.is_colorizer then
 			local found = false
 			for _, m in ipairs(merged) do
-				if m.is_colorizer and m.color == u.color and m.y == u.y and math.abs((m.x + m.w) - u.x) <= 1 then
+				if m.is_colorizer
+					and m.term ~= nil
+					and m.term == u.term
+					and m.color == u.color
+					and m.y == u.y
+					and math.abs((m.x + m.w) - u.x) <= 1 then
 					m.w = m.w + u.w
 					found = true
 					break
 				end
 			end
 			if not found then
-				table.insert(merged, { x = u.x, y = u.y, w = u.w, color = u.color, is_colorizer = true })
+				table.insert(merged, {
+					x = u.x,
+					y = u.y,
+					w = u.w,
+					color = u.color,
+					term = u.term,
+					is_colorizer = true,
+				})
 			end
 		else
 			table.insert(merged, u)

--- a/scripts/yomipv/interface/selector/renderer.lua
+++ b/scripts/yomipv/interface/selector/renderer.lua
@@ -428,7 +428,7 @@ function Renderer.render(selector)
 	end
 
 	-- Merge adjacent pieces of the same colorized term, but keep different
-	-- adjacent words visually separated even when they share the same color.
+	-- adjacent words visually separated even when they share the same color
 	local merged = {}
 	for _, u in ipairs(underlines) do
 		if u.is_colorizer then

--- a/scripts/yomipv/interface/selector/selector.lua
+++ b/scripts/yomipv/interface/selector/selector.lua
@@ -159,7 +159,35 @@ function Selector:clear_passive()
 	mp.set_osd_ass(0, 0, "")
 end
 
-function Selector:expand_selection_to_match(expression, reading)
+local function selection_len_from_original_length(selector, base_index, base_mora, original_len)
+	local remaining = tonumber(original_len) or 0
+	if remaining <= 0 then
+		return nil, nil
+	end
+
+	for i = 0, #selector.tokens - base_index do
+		local t = selector.tokens[base_index + i]
+		if t then
+			local tk_text = t.text
+			if i == 0 and base_mora and base_mora > 1 then
+				local byte_pos = StringOps.get_char_byte_pos(tk_text, base_mora)
+				tk_text = tk_text:sub(byte_pos)
+			end
+
+			local char_count = StringOps.get_char_count(tk_text)
+			if remaining < char_count then
+				return i + 1, remaining
+			elseif remaining == char_count then
+				return i + 1, nil
+			end
+			remaining = remaining - char_count
+		end
+	end
+
+	return nil, nil
+end
+
+function Selector:expand_selection_to_match(expression, reading, original_len)
 	if not self.active then
 		return
 	end
@@ -183,7 +211,17 @@ function Selector:expand_selection_to_match(expression, reading)
 	local base_index = (self.lookup_locked and self.locked_index) or self.index
 	local base_mora = (self.lookup_locked and self.locked_mora_index) or self.mora_index
 
+	local original_match_len, original_tail_mora =
+		selection_len_from_original_length(self, base_index, base_mora, original_len)
+	if original_match_len then
+		match_len = original_match_len
+		tail_mora = original_tail_mora
+	end
+
 	for i = 0, #self.tokens - base_index do
+		if match_len > 0 then
+			break
+		end
 		local t = self.tokens[base_index + i]
 		if t then
 			local tk_text = t.text
@@ -278,6 +316,7 @@ function Selector:confirm()
 		headwords = state.headwords,
 		offset = state.offset,
 		is_term = true,
+		capture_time_pos = mp.get_property_number("time-pos", 0),
 	}
 
 	if self.persistent_mode then

--- a/scripts/yomipv/lib/anki_db.lua
+++ b/scripts/yomipv/lib/anki_db.lua
@@ -578,7 +578,6 @@ local function build_reading_pieces(term, reading)
 	local pieces = {}
 	local reading_pos = 1
 	local i = 1
-	local has_literal = false
 
 	while i <= #chars do
 		local char = chars[i]
@@ -605,7 +604,6 @@ local function build_reading_pieces(term, reading)
 			if reading:sub(reading_pos, reading_pos + #char - 1) ~= char then
 				return nil
 			end
-			has_literal = true
 			table.insert(pieces, { original = char, replaceable = false })
 			reading_pos = reading_pos + #char
 			i = i + 1
@@ -613,9 +611,6 @@ local function build_reading_pieces(term, reading)
 	end
 
 	if reading_pos <= #reading then
-		return nil
-	end
-	if not has_literal then
 		return nil
 	end
 	return pieces
@@ -654,6 +649,42 @@ function get_reading_spelling_candidates(term, reading)
 		end
 	end
 	return candidates
+end
+
+local function collect_reading_piece_matches(db, hw, surface_text, matches)
+	if type(hw) ~= "table" then
+		return
+	end
+
+	local term = hw.term or hw.expression
+	local reading = hw.reading or term
+	if type(term) == "string" and term ~= ""
+		and type(reading) == "string" and reading ~= "" then
+		local pieces = build_reading_pieces(term, reading)
+		local surface_start = surface_text:find(term, 1, true)
+		if pieces and surface_start then
+			local term_offset = 0
+			for _, piece in ipairs(pieces) do
+				if piece.replaceable then
+					local entry, matched = find_clean_term(db, piece.replacement, { allow_reading_match = false })
+					local color = entry and word_color(entry) or nil
+					if color then
+						table.insert(matches, {
+							start_byte = surface_start + term_offset,
+							end_byte = surface_start + term_offset + #piece.original - 1,
+							color = color,
+							term = matched,
+						})
+					end
+				end
+				term_offset = term_offset + #piece.original
+			end
+		end
+	end
+
+	for _, child in ipairs(hw) do
+		collect_reading_piece_matches(db, child, surface_text, matches)
+	end
 end
 
 local function is_single_kana_string(text)
@@ -1129,6 +1160,18 @@ function AnkiDB.get_tokens_colors(tokens)
 								matched_color = nil
 								matched_term = nil
 							end
+						end
+					end
+					if not matched_len_bytes then
+						local piece_matches = {}
+						collect_reading_piece_matches(db, token.headwords, txt, piece_matches)
+						for _, match in ipairs(piece_matches) do
+							table.insert(intervals, {
+								start_byte = token_starts[t_idx] + match.start_byte - 1,
+								end_byte = token_starts[t_idx] + match.end_byte - 1,
+								color = match.color,
+								term = match.term,
+							})
 						end
 					end
 				end

--- a/scripts/yomipv/lib/anki_db.lua
+++ b/scripts/yomipv/lib/anki_db.lua
@@ -212,7 +212,10 @@ end
 
 local should_reject_single_yoon_reading
 
-local function find_clean_term(db, term)
+local function find_clean_term(db, term, opts)
+	opts = opts or {}
+	local allow_reading_match = opts.allow_reading_match ~= false
+
 	if type(term) ~= "string" or term == "" then return nil, nil, 0, nil end
 	local entry = db[term]
 	if entry then return entry, term, 0, "exact" end
@@ -232,7 +235,7 @@ local function find_clean_term(db, term)
 				return entry_for_base, base, base_stripped_bytes, kind
 			end
 
-			if _reading_index and is_kana_only(base) and utf8_char_count(base) >= 3 then
+			if allow_reading_match and _reading_index and is_kana_only(base) and utf8_char_count(base) >= 3 then
 				local reading_term = _reading_index[normalize_kana(base)]
 				if reading_term and reading_term ~= base then
 					local reading_entry = db[reading_term]
@@ -252,7 +255,8 @@ local function find_clean_term(db, term)
 		return stripped_entry, stripped, stripped_bytes, match_kind
 	end
 
-	if _reading_index
+	if allow_reading_match
+		and _reading_index
 		and is_kana_only(term)
 		and is_single_kana_script(term)
 		and utf8_char_count(term) >= 2 then
@@ -265,7 +269,7 @@ local function find_clean_term(db, term)
 		end
 	end
 
-	if _reading_index then
+	if allow_reading_match and _reading_index then
 		local reading_entry, reading_term, reading_stripped_bytes, reading_match_kind =
 			Conjugations.each_kana_adj_reading_term(term, { is_kana_only = is_kana_only }, function(
 				base,
@@ -289,12 +293,12 @@ local function find_clean_term(db, term)
 	return nil, nil, 0, nil
 end
 
-local function has_database_match(db, term)
+local function has_database_match(db, term, opts)
 	if type(term) ~= "string" or term == "" then
 		return false
 	end
 
-	local entry = find_clean_term(db, term)
+	local entry = find_clean_term(db, term, opts)
 	return entry ~= nil
 end
 
@@ -1038,7 +1042,9 @@ function AnkiDB.get_tokens_colors(tokens)
 
 				if not has_boundary and has_selectable and combined ~= "" then
 					local skip = options.colorizer_ignore_kana_only and not contains_kanji(combined)
-					if skip and has_database_match(db, combined) then skip = false end
+					if skip and has_database_match(db, combined, { allow_reading_match = false }) then
+						skip = false
+					end
 
 					if not skip then
 						local entry, matched, stripped, match_kind = find_clean_term(db, combined)
@@ -1063,7 +1069,7 @@ function AnkiDB.get_tokens_colors(tokens)
 				local token = tokens[t_idx]
 				local text_is_single_kana = is_single_kana_string(token.text or "")
 				local skip_kana = options.colorizer_ignore_kana_only and not contains_kanji(token.text or "")
-				if skip_kana and has_database_match(db, token.text) then
+				if skip_kana and has_database_match(db, token.text, { allow_reading_match = false }) then
 					skip_kana = false
 				end
 
@@ -1164,7 +1170,8 @@ function AnkiDB.get_tokens_colors(tokens)
 						match_kind = "compound_stem"
 					end
 					if entry then
-						if not (sub_is_kana_only and not has_database_match(db, sub)) then
+						local has_surface_match = has_database_match(db, sub, { allow_reading_match = false })
+						if not (sub_is_kana_only and not has_surface_match) then
 							local color = word_color(entry)
 							if color and not should_split_kana_particle(
 								get_surface_match_text(sub, stripped_bytes, match_kind),

--- a/scripts/yomipv/lib/anki_db.lua
+++ b/scripts/yomipv/lib/anki_db.lua
@@ -267,7 +267,11 @@ local function find_clean_term(db, term)
 
 	if _reading_index then
 		local reading_entry, reading_term, reading_stripped_bytes, reading_match_kind =
-			Conjugations.each_kana_adj_reading_term(term, { is_kana_only = is_kana_only }, function(base, base_stripped_bytes, kind)
+			Conjugations.each_kana_adj_reading_term(term, { is_kana_only = is_kana_only }, function(
+				base,
+				base_stripped_bytes,
+				kind
+			)
 				local resolved_term = _reading_index[normalize_kana(base)]
 				if resolved_term and resolved_term ~= base then
 				local entry_for_reading = db[resolved_term]

--- a/scripts/yomipv/lib/anki_db.lua
+++ b/scripts/yomipv/lib/anki_db.lua
@@ -5,12 +5,21 @@ local utils = require("mp.utils")
 local msg = require("mp.msg")
 local JSONFormat = require("lib.json_format")
 local Conjugations = require("lib.conjugations")
+local StringOps = require("lib.string_ops")
 local options = require("options")
 
 local AnkiDB = {}
 
 local _db = nil
+local _reading_index = nil
 local _loaded = false
+local utf8_char_count
+local is_kana_only
+local contains_hiragana
+local contains_katakana
+local contains_kanji
+local is_single_kana_script
+local utf8_char_len_at
 
 local function lerp_hex(r1, g1, b1, r2, g2, b2, t)
 	local r = math.floor(r1 + (r2 - r1) * t + 0.5)
@@ -36,12 +45,123 @@ local REVIEW_MAX = 2000
 local REVIEW_R1, REVIEW_G1, REVIEW_B1 = 0xAA, 0xFF, 0x00
 local REVIEW_R2, REVIEW_G2, REVIEW_B2 = 0x00, 0xFF, 0xCC
 
+local function trim(text)
+	if type(text) ~= "string" then return nil end
+	local trimmed = text:gsub("^%s*(.-)%s*$", "%1")
+	return trimmed ~= "" and trimmed or nil
+end
+
+local function each_entry_reading(entry, callback)
+	if type(entry) ~= "table" then
+		return
+	end
+
+	if type(entry.reading) == "string" then
+		local reading = trim(entry.reading)
+		if reading then callback(reading) end
+	elseif type(entry.reading) == "table" then
+		for _, value in ipairs(entry.reading) do
+			local reading = trim(value)
+			if reading then callback(reading) end
+		end
+	end
+end
+
+local function codepoint_to_utf8(code)
+	if code <= 0x7F then
+		return string.char(code)
+	elseif code <= 0x7FF then
+		return string.char(
+			0xC0 + math.floor(code / 0x40),
+			0x80 + (code % 0x40)
+		)
+	elseif code <= 0xFFFF then
+		return string.char(
+			0xE0 + math.floor(code / 0x1000),
+			0x80 + (math.floor(code / 0x40) % 0x40),
+			0x80 + (code % 0x40)
+		)
+	end
+	return string.char(
+		0xF0 + math.floor(code / 0x40000),
+		0x80 + (math.floor(code / 0x1000) % 0x40),
+		0x80 + (math.floor(code / 0x40) % 0x40),
+		0x80 + (code % 0x40)
+	)
+end
+
+local function normalize_kana(text)
+	if type(text) ~= "string" or text == "" then
+		return nil
+	end
+
+	local chars = {}
+	for _, code in StringOps.utf8_codes(text) do
+		if code >= 0x30A1 and code <= 0x30FA then
+			code = code - 0x60
+		end
+		table.insert(chars, codepoint_to_utf8(code))
+	end
+	return table.concat(chars)
+end
+
+local yoon_initials = {
+	["き"] = true, ["ぎ"] = true,
+	["し"] = true, ["じ"] = true,
+	["ち"] = true,
+	["に"] = true,
+	["ひ"] = true, ["び"] = true, ["ぴ"] = true,
+	["み"] = true,
+	["り"] = true,
+}
+
+local yoon_smalls = {
+	["ゃ"] = true,
+	["ゅ"] = true,
+	["ょ"] = true,
+}
+
+local function is_single_yoon_mora(text)
+	local normalized = normalize_kana(text)
+	if not normalized or StringOps.get_char_count(normalized) ~= 2 then
+		return false
+	end
+
+	local chars = {}
+	for _, code in StringOps.utf8_codes(normalized) do
+		table.insert(chars, codepoint_to_utf8(code))
+	end
+	return yoon_initials[chars[1]] == true and yoon_smalls[chars[2]] == true
+end
+
+local function build_reading_index(db)
+	local unique_terms = {}
+	local ambiguous = {}
+
+	for term, entry in pairs(db) do
+		if type(term) == "string" and type(entry) == "table" then
+			each_entry_reading(entry, function(raw_reading)
+				local reading = normalize_kana(raw_reading)
+				if reading and not ambiguous[reading] then
+					if unique_terms[reading] == nil or unique_terms[reading] == term then
+						unique_terms[reading] = term
+					else
+						unique_terms[reading] = nil
+						ambiguous[reading] = true
+					end
+				end
+			end)
+		end
+	end
+
+	return unique_terms
+end
+
 local function load_db()
 	if _loaded then
 		return _db
 	end
 	_loaded = true
-
 	local path = mp.find_config_file("script-opts/anki_words.json")
 	if not path then
 		msg.warn("anki_db: anki_words.json not found in script-opts/")
@@ -64,6 +184,7 @@ local function load_db()
 	end
 
 	_db = parsed.words
+	_reading_index = build_reading_index(_db)
 	local count = 0
 	for _ in pairs(_db) do count = count + 1 end
 	msg.info("anki_db: loaded " .. tostring(count) .. " words")
@@ -89,63 +210,7 @@ local function word_color(entry)
 	return nil
 end
 
-local function callback_deconjugated_base(base, stripped_bytes, kind, callback)
-	for _, candidate in ipairs(Conjugations.get_base_candidates(base)) do
-		local r1, r2, r3, r4 = callback(candidate, stripped_bytes, kind)
-		if r1 ~= nil then return r1, r2, r3, r4 end
-	end
-	return nil
-end
-
-local function each_deconjugated_term(term, callback)
-	if type(term) ~= "string" or term == "" then
-		return nil
-	end
-
-	for _, p in ipairs(Conjugations.noun_suffixes) do
-		if #term > #p and term:sub(-#p) == p then
-			local stripped = term:sub(1, -(#p + 1))
-			if #stripped >= 3 then
-				local r1, r2, r3, r4 = callback_deconjugated_base(stripped, #p, "suffix_strip", callback)
-				if r1 ~= nil then return r1, r2, r3, r4 end
-			end
-		end
-	end
-
-	for _, adj in ipairs(Conjugations.adj_endings) do
-		local p = adj.ending
-		if #term > #p and term:sub(-#p) == p then
-			local stripped = term:sub(1, -(#p + 1)) .. adj.rep
-			if #stripped >= 3 and not Conjugations.is_invalid_adj_base(term, stripped) then
-				local r1, r2, r3, r4 = callback_deconjugated_base(stripped, 0, "inflection", callback)
-				if r1 ~= nil then return r1, r2, r3, r4 end
-			end
-		end
-	end
-
-	for _, p in ipairs(Conjugations.na_adj_endings) do
-		if #term > #p and term:sub(-#p) == p then
-			local stripped = term:sub(1, -(#p + 1))
-			if #stripped >= 3 then
-				local r1, r2, r3, r4 = callback_deconjugated_base(stripped, 0, "inflection", callback)
-				if r1 ~= nil then return r1, r2, r3, r4 end
-			end
-		end
-	end
-
-	for _, verb in ipairs(Conjugations.verb_endings) do
-		local p = verb.ending
-		if Conjugations.is_valid_verb_match(term, p, verb.rep) and term:sub(-#p) == p then
-			local stripped = term:sub(1, -(#p + 1)) .. verb.rep
-			if #stripped >= 3 then
-				local r1, r2, r3, r4 = callback_deconjugated_base(stripped, 0, "inflection", callback)
-				if r1 ~= nil then return r1, r2, r3, r4 end
-			end
-		end
-	end
-
-	return nil
-end
+local should_reject_single_yoon_reading
 
 local function find_clean_term(db, term)
 	if type(term) ~= "string" or term == "" then return nil, nil, 0, nil end
@@ -158,17 +223,63 @@ local function find_clean_term(db, term)
 		end
 	end
 
-	local stripped_entry, stripped, stripped_bytes, match_kind = each_deconjugated_term(
+	local stripped_entry, stripped, stripped_bytes, match_kind = Conjugations.each_deconjugated_term(
 		term,
+		{ contains_kanji = contains_kanji },
 		function(base, base_stripped_bytes, kind)
-		local entry_for_base = db[base]
-		if entry_for_base then
-			return entry_for_base, base, base_stripped_bytes, kind
+			local entry_for_base = db[base]
+			if entry_for_base then
+				return entry_for_base, base, base_stripped_bytes, kind
+			end
+
+			if _reading_index and is_kana_only(base) and utf8_char_count(base) >= 3 then
+				local reading_term = _reading_index[normalize_kana(base)]
+				if reading_term and reading_term ~= base then
+					local reading_entry = db[reading_term]
+					local reject_mixed_kana_suru = contains_katakana(base)
+						and reading_term:sub(-#"する") == "する"
+						and contains_kanji(reading_term)
+					if reading_entry
+						and not reject_mixed_kana_suru
+						and not should_reject_single_yoon_reading(db, base, reading_term) then
+						return reading_entry, reading_term, base_stripped_bytes, kind
+					end
+				end
+			end
 		end
-	end
 	)
 	if stripped_entry then
 		return stripped_entry, stripped, stripped_bytes, match_kind
+	end
+
+	if _reading_index
+		and is_kana_only(term)
+		and is_single_kana_script(term)
+		and utf8_char_count(term) >= 2 then
+		local reading_term = _reading_index[normalize_kana(term)]
+		if reading_term and reading_term ~= term then
+			local reading_entry = db[reading_term]
+			if reading_entry and not should_reject_single_yoon_reading(db, term, reading_term) then
+				return reading_entry, reading_term, 0, "exact"
+			end
+		end
+	end
+
+	if _reading_index then
+		local reading_entry, reading_term, reading_stripped_bytes, reading_match_kind =
+			Conjugations.each_kana_adj_reading_term(term, { is_kana_only = is_kana_only }, function(base, base_stripped_bytes, kind)
+				local resolved_term = _reading_index[normalize_kana(base)]
+				if resolved_term and resolved_term ~= base then
+				local entry_for_reading = db[resolved_term]
+				if entry_for_reading
+					and not should_reject_single_yoon_reading(db, base, resolved_term) then
+					return entry_for_reading, resolved_term, base_stripped_bytes, kind
+				end
+			end
+		end)
+		if reading_entry then
+			return reading_entry, reading_term, reading_stripped_bytes, reading_match_kind
+		end
 	end
 
 	return nil, nil, 0, nil
@@ -183,11 +294,110 @@ local function has_database_match(db, term)
 	return entry ~= nil
 end
 
+local function get_particle_stripped_prefix_bytes(db, surface_text, matched_term)
+	if type(surface_text) ~= "string" or surface_text == ""
+		or type(matched_term) ~= "string" or matched_term == "" then
+		return nil
+	end
+
+	for _, suffix in ipairs(Conjugations.verb_particle_suffixes or {}) do
+		if #surface_text > #suffix and surface_text:sub(-#suffix) == suffix then
+			local prefix = surface_text:sub(1, -(#suffix + 1))
+			local entry, resolved_term = find_clean_term(db, prefix)
+			if entry and resolved_term == matched_term then
+				return #prefix
+			end
+		end
+	end
+
+	return nil
+end
+
+local function find_compound_verb_stem(db, term)
+	if type(term) ~= "string" or term == "" then
+		return nil, nil, nil
+	end
+
+	for _, stem in ipairs(Conjugations.compound_verb_stems or {}) do
+		local ending = stem.ending
+		if #term > #ending and term:sub(-#ending) == ending then
+			local base = term:sub(1, -(#ending + 1)) .. stem.rep
+			if #base >= 3 then
+				for _, candidate in ipairs(Conjugations.get_base_candidates(base)) do
+					local entry = db[candidate]
+					if entry then
+						return entry, candidate, #term
+					end
+				end
+			end
+		end
+	end
+
+	return nil, nil, nil
+end
+
+should_reject_single_yoon_reading = function(db, surface, matched_term)
+	return is_single_yoon_mora(surface)
+		and not db[surface]
+		and contains_kanji(matched_term)
+end
+
+local function remove_last_utf8_char(text)
+	if type(text) ~= "string" or text == "" then return nil end
+
+	local last = 1
+	local i = 1
+	while i <= #text do
+		last = i
+		i = i + utf8_char_len_at(text, i)
+	end
+	return text:sub(1, last - 1)
+end
+
 local function get_surface_match_bytes(surface_text, stripped_bytes, match_kind)
 	if match_kind == "suffix_strip" then
 		return math.max(0, #surface_text - (stripped_bytes or 0))
 	end
 	return #surface_text
+end
+
+local function get_surface_match_text(surface_text, stripped_bytes, match_kind)
+	local match_bytes = get_surface_match_bytes(surface_text, stripped_bytes, match_kind)
+	if match_bytes <= 0 then return "" end
+	return surface_text:sub(1, match_bytes)
+end
+
+local function get_literal_prefix_match_bytes(surface_text, matched_term)
+	if type(surface_text) ~= "string" or surface_text == ""
+		or type(matched_term) ~= "string" or matched_term == "" then
+		return nil
+	end
+
+	if surface_text:sub(1, #matched_term) == matched_term then
+		return #matched_term
+	end
+
+	local normalized_surface = normalize_kana(surface_text)
+	local normalized_term = normalize_kana(matched_term)
+	if normalized_surface and normalized_term
+		and normalized_surface:sub(1, #normalized_term) == normalized_term then
+		local i = 1
+		local matched_bytes = 0
+		local normalized_bytes = 0
+		while i <= #surface_text and normalized_bytes < #normalized_term do
+			local char_len = utf8_char_len_at(surface_text, i)
+			local char = surface_text:sub(i, i + char_len - 1)
+			local normalized_char = normalize_kana(char) or char
+			normalized_bytes = normalized_bytes + #normalized_char
+			matched_bytes = matched_bytes + char_len
+			i = i + char_len
+		end
+		if normalized_bytes == #normalized_term then
+			return matched_bytes
+		end
+	end
+
+	return nil
 end
 
 local function get_source_match_bytes(source, surface)
@@ -225,6 +435,19 @@ local function get_headword_source_match_bytes(hw, surface)
 	return nil
 end
 
+local function get_headword_match_source(hw, surface)
+	if type(hw) ~= "table" or type(hw.sources) ~= "table" then
+		return nil
+	end
+
+	for _, source in ipairs(hw.sources) do
+		if get_source_match_bytes(source, surface) then
+			return source.matchSource
+		end
+	end
+	return nil
+end
+
 local get_reading_spelling_candidates
 
 local function resolve_term_color(db, hw, surface_text)
@@ -240,34 +463,39 @@ local function resolve_term_color(db, hw, surface_text)
 			local entry, matched, stripped, match_kind = find_clean_term(db, term)
 			if entry then
 				return word_color(entry), matched, stripped, hw_reading, match_kind,
-					get_headword_source_match_bytes(hw, surface_text)
+					get_headword_source_match_bytes(hw, surface_text),
+					get_headword_match_source(hw, surface_text)
 			end
 		end
 		for _, candidate in ipairs(get_reading_spelling_candidates(term, hw_reading)) do
 			local entry, matched, stripped, match_kind = find_clean_term(db, candidate)
 			if entry then
 				return word_color(entry), matched, stripped, hw_reading, match_kind,
-					get_headword_source_match_bytes(hw, surface_text)
+					get_headword_source_match_bytes(hw, surface_text),
+					get_headword_match_source(hw, surface_text)
 			end
 		end
 		if type(hw_reading) == "string" and hw_reading ~= "" and hw_reading ~= term then
 			local entry, matched, stripped, match_kind = find_clean_term(db, hw_reading)
 			if entry then
 				return word_color(entry), matched, stripped, hw_reading, match_kind,
-					get_headword_source_match_bytes(hw, surface_text)
+					get_headword_source_match_bytes(hw, surface_text),
+					get_headword_match_source(hw, surface_text)
 			end
 		end
 
 		for _, v in ipairs(hw) do
-			local color, found_term, stripped, found_reading, match_kind, source_match_bytes =
+			local color, found_term, stripped, found_reading, match_kind, source_match_bytes, source_kind =
 				resolve_term_color(db, v, surface_text)
-			if color then return color, found_term, stripped, found_reading, match_kind, source_match_bytes end
+			if color then
+				return color, found_term, stripped, found_reading, match_kind, source_match_bytes, source_kind
+			end
 		end
 	end
 	return nil
 end
 
-local function contains_kanji(text)
+contains_kanji = function(text)
 	if type(text) ~= "string" or text == "" then return false end
 	local i = 1
 	local len = #text
@@ -426,7 +654,58 @@ local function is_single_kana_string(text)
 	return b1 == 0xE3 and (b2 == 0x81 or b2 == 0x82 or b2 == 0x83)
 end
 
-local function utf8_char_len_at(text, byte_index)
+contains_hiragana = function(text)
+	if type(text) ~= "string" or text == "" then return false end
+	local i = 1
+	while i <= #text do
+		local b1, b2, b3 = text:byte(i, i + 2)
+		if b1 == 0xE3 and b2 == 0x81 and b3 and b3 >= 0x81 then
+			return true
+		end
+		if b1 and b1 >= 0xF0 then
+			i = i + 4
+		elseif b1 and b1 >= 0xE0 then
+			i = i + 3
+		elseif b1 and b1 >= 0xC0 then
+			i = i + 2
+		else
+			i = i + 1
+		end
+	end
+	return false
+end
+
+contains_katakana = function(text)
+	if type(text) ~= "string" or text == "" then return false end
+	local i = 1
+	while i <= #text do
+		local b1, b2, b3 = text:byte(i, i + 2)
+		if b1 == 0xE3 and (
+			(b2 == 0x82 and b3 and b3 >= 0xA0) or
+			(b2 == 0x83 and b3 and b3 <= 0xBF)
+		) then
+			return true
+		end
+		if b1 and b1 >= 0xF0 then
+			i = i + 4
+		elseif b1 and b1 >= 0xE0 then
+			i = i + 3
+		elseif b1 and b1 >= 0xC0 then
+			i = i + 2
+		else
+			i = i + 1
+		end
+	end
+	return false
+end
+
+is_single_kana_script = function(text)
+	local has_hiragana = contains_hiragana(text)
+	local has_katakana = contains_katakana(text)
+	return (has_hiragana or has_katakana) and not (has_hiragana and has_katakana)
+end
+
+utf8_char_len_at = function(text, byte_index)
 	local byte = text:byte(byte_index)
 	if not byte then return 1 end
 	if byte >= 0xC0 then
@@ -439,7 +718,7 @@ local function utf8_char_len_at(text, byte_index)
 	return 1
 end
 
-local function utf8_char_count(text)
+utf8_char_count = function(text)
 	if type(text) ~= "string" or text == "" then
 		return 0
 	end
@@ -453,6 +732,48 @@ local function utf8_char_count(text)
 	return count
 end
 
+is_kana_only = function(text)
+	if type(text) ~= "string" or text == "" then
+		return false
+	end
+
+	local i = 1
+	while i <= #text do
+		local b1, b2, b3 = text:byte(i, i + 2)
+		if b1 == 0xE3 and b2 and b3 then
+			local is_hiragana = (b2 == 0x81 and b3 >= 0x81 and b3 <= 0xBF)
+				or (b2 == 0x82 and b3 >= 0x80 and b3 <= 0x9F)
+			local is_katakana = (b2 == 0x82 and b3 >= 0xA0 and b3 <= 0xBF)
+				or (b2 == 0x83 and b3 >= 0x80 and b3 <= 0xBF)
+			if is_hiragana or is_katakana then
+				i = i + 3
+			else
+				return false
+			end
+		else
+			return false
+		end
+	end
+
+	return true
+end
+
+local boundary_chars = {
+	["。"] = true, ["、"] = true, ["？"] = true, ["！"] = true, ["…"] = true,
+	["「"] = true, ["」"] = true, ["『"] = true, ["』"] = true,
+	["（"] = true, ["）"] = true, ["【"] = true, ["】"] = true,
+	["〔"] = true, ["〕"] = true, ["〈"] = true, ["〉"] = true,
+	["《"] = true, ["》"] = true,
+}
+
+local function is_boundary_char(char)
+	if type(char) ~= "string" or char == "" then return false end
+	if #char == 1 then
+		return char:match("[%s%p]") ~= nil
+	end
+	return boundary_chars[char] == true
+end
+
 local function matches_base_form(term, target)
 	if type(term) ~= "string" or term == "" or type(target) ~= "string" or target == "" then
 		return false
@@ -462,7 +783,7 @@ local function matches_base_form(term, target)
 		return true
 	end
 
-	return each_deconjugated_term(term, function(base)
+	return Conjugations.each_deconjugated_term(term, { contains_kanji = contains_kanji }, function(base)
 		if base == target then
 			return true
 		end
@@ -477,8 +798,16 @@ local function token_matches_headword(token_text, token_reading, matched_term, m
 	local reading = (type(token_reading) == "string" and token_reading ~= "") and token_reading or token_text
 	local headword_reading = (type(matched_reading) == "string" and matched_reading ~= "")
 		and matched_reading or matched_term
+	local normalized_token_text = normalize_kana(token_text) or token_text
+	local normalized_matched_term = normalize_kana(matched_term) or matched_term
+	local normalized_reading = normalize_kana(reading) or reading
+	local normalized_headword_reading = normalize_kana(headword_reading) or headword_reading
 
 	if token_text == matched_term then
+		return true
+	end
+
+	if normalized_token_text == normalized_matched_term then
 		return true
 	end
 
@@ -486,11 +815,23 @@ local function token_matches_headword(token_text, token_reading, matched_term, m
 		return true
 	end
 
+	if normalized_reading == normalized_headword_reading then
+		return true
+	end
+
 	if matches_base_form(token_text, matched_term) then
 		return true
 	end
 
+	if matches_base_form(normalized_token_text, normalized_matched_term) then
+		return true
+	end
+
 	if matches_base_form(reading, headword_reading) then
+		return true
+	end
+
+	if matches_base_form(normalized_reading, normalized_headword_reading) then
 		return true
 	end
 
@@ -539,25 +880,159 @@ function AnkiDB.get_tokens_colors(tokens)
 		return nil
 	end
 
+	local function char_at(byte_offset)
+		if type(byte_offset) ~= "number" or byte_offset > #full_text then return nil end
+		local char_len = utf8_char_len_at(full_text, byte_offset)
+		return full_text:sub(byte_offset, byte_offset + char_len - 1), char_len
+	end
+
+	local function char_before(byte_offset)
+		if type(byte_offset) ~= "number" or byte_offset <= 1 then return nil end
+		local last = nil
+		local i = 1
+		while i < byte_offset do
+			last = i
+			i = i + utf8_char_len_at(full_text, i)
+		end
+		if not last then return nil end
+		return char_at(last)
+	end
+
+	local function is_pure_katakana_text(text)
+		return is_kana_only(text) and contains_katakana(text) and not contains_hiragana(text)
+	end
+
+	local function is_katakana_char(char)
+		return type(char) == "string" and char ~= "" and is_pure_katakana_text(char)
+	end
+
+	local function is_whole_katakana_run(start_byte, match_bytes)
+		if type(match_bytes) ~= "number" or match_bytes <= 0 then return true end
+
+		local matched_text = full_text:sub(start_byte, start_byte + match_bytes - 1)
+		if not is_pure_katakana_text(matched_text) then
+			return true
+		end
+
+		local prev_char = char_before(start_byte)
+		if is_katakana_char(prev_char) then
+			return false
+		end
+
+		local next_char = char_at(start_byte + match_bytes)
+		return not is_katakana_char(next_char)
+	end
+
+	local function has_particle_kana_continuation(byte_offset)
+		if byte_offset > #full_text then return true end
+
+		local char, char_len = char_at(byte_offset)
+		if not char then return true end
+		if is_boundary_char(char) then return true end
+
+		local normalized = normalize_kana(char)
+		if normalized == "っ" then
+			local next_char = char_at(byte_offset + char_len)
+			return normalize_kana(next_char) == "て"
+		end
+		return normalized == "と" or normalized == "あ" or normalized == "ぁ"
+	end
+
+	local protected_particles = {}
+
+	local function protect_kana_particle(start_byte)
+		protected_particles[start_byte] = start_byte + #"かな" - 1
+	end
+
+	local function should_split_kana_particle(surface, matched, start_byte)
+		if type(surface) ~= "string" or surface == ""
+			or type(matched) ~= "string" or matched == "" then
+			return false
+		end
+		if contains_kanji(surface) or not is_kana_only(surface) then
+			return false
+		end
+
+		local normalized_surface = normalize_kana(surface)
+		if not normalized_surface or normalized_surface:sub(-#"か") ~= "か" then
+			return false
+		end
+
+		local next_byte = start_byte + #surface
+		local next_char, next_len = char_at(next_byte)
+		if normalize_kana(next_char) ~= "な" then
+			return false
+		end
+		if not has_particle_kana_continuation(next_byte + next_len) then
+			return false
+		end
+
+		local prefix = remove_last_utf8_char(surface)
+		if has_database_match(db, prefix) then
+			protect_kana_particle(start_byte + #prefix)
+			return true
+		end
+		return false
+	end
+
+	local function kana_particle_prefix_match(surface, start_byte)
+		if type(surface) ~= "string" or surface == "" then
+			return nil, nil, nil
+		end
+		local prefix = remove_last_utf8_char(surface)
+		if not prefix or prefix == "" then
+			return nil, nil, nil
+		end
+		local entry, matched = find_clean_term(db, prefix)
+		if entry and should_split_kana_particle(surface, matched, start_byte) then
+			return entry, matched, #prefix
+		end
+		return nil, nil, nil
+	end
+
+	local function set_protected_particle_match(byte_offset)
+		local protected_end = protected_particles[byte_offset]
+		if not protected_end then return nil, nil, nil end
+
+		local entry = db["かな"]
+		local color = word_color(entry)
+		if color then
+			return #"かな", color, "かな"
+		end
+		return protected_end - byte_offset + 1, nil, nil
+	end
+
 	local intervals = {}
 
 	while b <= #full_text do
-		local matched_len_bytes = nil
-		local matched_color = nil
-		local matched_term = nil
+		local matched_len_bytes, matched_color, matched_term = set_protected_particle_match(b)
 
 		local t_idx = get_token_idx(b)
 
-		if t_idx and b == token_starts[t_idx] then
+		if not matched_len_bytes and t_idx and b == token_starts[t_idx] then
 			for len = math.min(6, n - t_idx + 1), 2, -1 do
 				local has_selectable = false
 				local combined = ""
+				local has_boundary = false
 				for k = t_idx, t_idx + len - 1 do
-					combined = combined .. (tokens[k].text or "")
+					local ttxt = tokens[k].text or ""
+					if ttxt ~= "" then
+						local ci = 1
+						while ci <= #ttxt do
+							local clen = utf8_char_len_at(ttxt, ci)
+							if is_boundary_char(ttxt:sub(ci, ci + clen - 1)) then
+								has_boundary = true
+								break
+							end
+							ci = ci + clen
+						end
+					end
+					if has_boundary then break end
+					combined = combined .. ttxt
 					if tokens[k].is_term then has_selectable = true end
 				end
 
-				if has_selectable and combined ~= "" then
+				if not has_boundary and has_selectable and combined ~= "" then
 					local skip = options.colorizer_ignore_kana_only and not contains_kanji(combined)
 					if skip and has_database_match(db, combined) then skip = false end
 
@@ -566,10 +1041,14 @@ function AnkiDB.get_tokens_colors(tokens)
 						if entry then
 							local color = word_color(entry)
 							if color then
-								matched_len_bytes = get_surface_match_bytes(combined, stripped, match_kind)
-								matched_color = color
-								matched_term = matched
-								break
+								local literal_prefix_bytes = get_literal_prefix_match_bytes(combined, matched)
+								local combined_match_bytes = get_surface_match_bytes(combined, stripped, match_kind)
+								if not literal_prefix_bytes and combined_match_bytes == #combined then
+									matched_len_bytes = combined_match_bytes
+									matched_color = color
+									matched_term = matched
+									break
+								end
 							end
 						end
 					end
@@ -586,14 +1065,60 @@ function AnkiDB.get_tokens_colors(tokens)
 
 				if token.headwords and not text_is_single_kana and not skip_kana then
 					local txt = token.text or ""
-					local color, term_matched, stripped_bytes, hw_reading, match_kind, source_match_bytes =
+					local color, term_matched, stripped_bytes, hw_reading, match_kind, source_match_bytes, source_kind =
 						resolve_term_color(db, token.headwords, txt)
 					if color then
 						local tok_reading = (token.reading ~= "" and token.reading) or txt
-						if source_match_bytes or token_matches_headword(txt, tok_reading, term_matched, hw_reading) then
-							matched_len_bytes = source_match_bytes or get_surface_match_bytes(txt, stripped_bytes, match_kind)
-							matched_color = color
-							matched_term = term_matched
+						local has_explicit_token_reading = type(token.reading) == "string" and token.reading ~= ""
+						local mixed_kana = not contains_kanji(txt) and contains_hiragana(txt) and contains_katakana(txt)
+						local reject_reading_mismatch = source_kind == "reading"
+							and has_explicit_token_reading
+							and hw_reading ~= nil
+							and token.reading ~= hw_reading
+						local reject_reading_kanji = mixed_kana
+							and source_kind == "reading"
+							and contains_kanji(term_matched)
+						local headword_compatible
+						if source_kind == "reading" then
+							headword_compatible = has_explicit_token_reading
+								and token_matches_headword(txt, token.reading, term_matched, hw_reading)
+						else
+							headword_compatible = token_matches_headword(txt, tok_reading, term_matched, hw_reading)
+						end
+						if not reject_reading_mismatch
+							and not reject_reading_kanji
+							and ((source_match_bytes and headword_compatible) or headword_compatible) then
+							local preferred_match_bytes = get_surface_match_bytes(txt, stripped_bytes, match_kind)
+							local literal_prefix_bytes = get_literal_prefix_match_bytes(txt, term_matched)
+							local particle_prefix_bytes = get_particle_stripped_prefix_bytes(db, txt, term_matched)
+							local prefix_entry, prefix_matched, prefix_bytes =
+								kana_particle_prefix_match(
+									get_surface_match_text(txt, stripped_bytes, match_kind),
+									token_starts[t_idx]
+								)
+							if prefix_entry then
+								matched_len_bytes = prefix_bytes
+								matched_color = word_color(prefix_entry)
+								matched_term = prefix_matched
+							elseif literal_prefix_bytes and literal_prefix_bytes < preferred_match_bytes then
+								matched_len_bytes = literal_prefix_bytes
+							elseif particle_prefix_bytes and particle_prefix_bytes < preferred_match_bytes then
+								matched_len_bytes = particle_prefix_bytes
+							elseif source_match_bytes and match_kind ~= "suffix_strip" then
+								matched_len_bytes = source_match_bytes
+							else
+								matched_len_bytes = preferred_match_bytes
+							end
+							if not prefix_entry then
+								matched_color = color
+								matched_term = term_matched
+							end
+							if matched_len_bytes
+								and not is_whole_katakana_run(token_starts[t_idx], matched_len_bytes) then
+								matched_len_bytes = nil
+								matched_color = nil
+								matched_term = nil
+							end
 						end
 					end
 				end
@@ -609,6 +1134,10 @@ function AnkiDB.get_tokens_colors(tokens)
 			local j = b
 			while j <= #full_text and char_count < 20 do
 				local char_len = utf8_char_len_at(full_text, j)
+				local char = full_text:sub(j, j + char_len - 1)
+				if is_boundary_char(char) then
+					break
+				end
 				j = j + char_len
 				char_count = char_count + 1
 
@@ -619,13 +1148,34 @@ function AnkiDB.get_tokens_colors(tokens)
 				local sub_is_kana_only = options.colorizer_ignore_kana_only and not contains_kanji(sub)
 				if not is_single_kana and (sub_char_count >= 2 or contains_kanji(sub)) then
 					local entry, matched, stripped_bytes, match_kind = find_clean_term(db, sub)
+					local compound_stem_entry, compound_stem_matched, compound_stem_bytes
+					if j <= #full_text and not entry then
+						compound_stem_entry, compound_stem_matched, compound_stem_bytes =
+							find_compound_verb_stem(db, sub)
+					end
+					if compound_stem_entry then
+						entry = compound_stem_entry
+						matched = compound_stem_matched
+						stripped_bytes = 0
+						match_kind = "compound_stem"
+					end
 					if entry then
 						if not (sub_is_kana_only and not has_database_match(db, sub)) then
 							local color = word_color(entry)
-							if color then
-								best_match_bytes = get_surface_match_bytes(sub, stripped_bytes, match_kind)
-								best_color = color
-								best_term = matched
+							if color and not should_split_kana_particle(
+								get_surface_match_text(sub, stripped_bytes, match_kind),
+								matched,
+								b
+							) then
+								local literal_prefix_bytes = get_literal_prefix_match_bytes(sub, matched)
+								local candidate_match_bytes = literal_prefix_bytes
+									or compound_stem_bytes
+									or get_surface_match_bytes(sub, stripped_bytes, match_kind)
+								if is_whole_katakana_run(b, candidate_match_bytes) then
+									best_match_bytes = candidate_match_bytes
+									best_color = color
+									best_term = matched
+								end
 							end
 						end
 					end
@@ -640,12 +1190,14 @@ function AnkiDB.get_tokens_colors(tokens)
 		end
 
 		if matched_len_bytes and matched_len_bytes > 0 then
-			table.insert(intervals, {
-				start_byte = b,
-				end_byte = b + matched_len_bytes - 1,
-				color = matched_color,
-				term = matched_term
-			})
+			if matched_color then
+				table.insert(intervals, {
+					start_byte = b,
+					end_byte = b + matched_len_bytes - 1,
+					color = matched_color,
+					term = matched_term
+				})
+			end
 			b = b + matched_len_bytes
 		else
 			b = b + utf8_char_len_at(full_text, b)
@@ -678,6 +1230,7 @@ end
 -- Forces a reload on next access
 function AnkiDB.reload()
 	_db = nil
+	_reading_index = nil
 	_loaded = false
 end
 

--- a/scripts/yomipv/lib/conjugations.lua
+++ b/scripts/yomipv/lib/conjugations.lua
@@ -23,6 +23,8 @@ sort_string_rules(noun_suffixes)
 Conjugations.noun_suffixes = noun_suffixes
 
 local adj_endings = {
+	{ ending = "ではなかった", rep = "ではない" },
+	{ ending = "じゃなかった", rep = "じゃない" },
 	{ ending = "よくありませんでした", rep = "いい" },
 	{ ending = "よくなかったです", rep = "いい" },
 	{ ending = "よくありません", rep = "いい" },
@@ -74,6 +76,10 @@ sort_pair_rules(adj_endings)
 Conjugations.adj_endings = adj_endings
 
 local base_candidates = {
+	-- Negative copula/adjective phrase variants
+	["じゃなかった"] = { "じゃない" },
+	["ではなかった"] = { "ではない" },
+
 	-- Common adjective spelling/kanji variants
 	["いい"] = { "良い", "よい", "いい" },
 	["よい"] = { "良い", "よい", "いい" },
@@ -90,6 +96,7 @@ local base_candidates = {
 	["うけ"] = { "受け", "うけ" },
 	["きらい"] = { "嫌い", "きらい" },
 	["くび"] = { "首", "くび" },
+	["くる"] = { "来る", "くる" },
 	["けさ"] = { "今朝", "けさ" },
 	["けいたい"] = { "携帯", "けいたい" },
 	["こと"] = { "事", "こと" },
@@ -127,6 +134,14 @@ function Conjugations.get_base_candidates(base)
 	return base_candidates[base] or { base }
 end
 
+local compound_verb_stems = {
+	{ ending = "い", rep = "う" },
+}
+sort_pair_rules(compound_verb_stems)
+Conjugations.compound_verb_stems = compound_verb_stems
+
+Conjugations.verb_particle_suffixes = { "よ" }
+
 local kana_adj_bases = {
 	["すごい"] = true,
 	["はやい"] = true,
@@ -150,6 +165,10 @@ function Conjugations.is_invalid_adj_base(term, base)
 		return false
 	end
 
+	if base == "じゃない" or base == "ではない" then
+		return false
+	end
+
 	if base == "いい" or base == "よい" then
 		return term:sub(1, #"よ") ~= "よ"
 	end
@@ -167,7 +186,124 @@ function Conjugations.is_valid_verb_match(term, ending, rep)
 		return true
 	end
 
+	if (rep == "くる" or rep == "来る")
+		and #term == #ending
+		and (ending == "きた" or ending == "きて" or ending == "来た" or ending == "来て") then
+		return true
+	end
+
 	return rep == "する" and #term == #ending and #ending >= #"した"
+end
+
+local function callback_deconjugated_base(base, stripped_bytes, kind, callback)
+	for _, candidate in ipairs(Conjugations.get_base_candidates(base)) do
+		local r1, r2, r3, r4 = callback(candidate, stripped_bytes, kind)
+		if r1 ~= nil then return r1, r2, r3, r4 end
+	end
+	return nil
+end
+
+function Conjugations.each_deconjugated_term(term, opts, callback)
+	if type(opts) == "function" and callback == nil then
+		callback = opts
+		opts = {}
+	end
+	opts = opts or {}
+
+	if type(term) ~= "string" or term == "" then
+		return nil
+	end
+
+	local contains_kanji = opts.contains_kanji or function() return false end
+
+	local function try_verb_rules(surface, stripped_bytes, kind)
+		for _, verb in ipairs(Conjugations.verb_endings) do
+			local p = verb.ending
+			if (not verb.kanji_surface_only or contains_kanji(surface))
+				and Conjugations.is_valid_verb_match(surface, p, verb.rep)
+				and surface:sub(-#p) == p then
+				local stripped = surface:sub(1, -(#p + 1)) .. verb.rep
+				if #stripped >= 3 then
+					local r1, r2, r3, r4 = callback_deconjugated_base(stripped, stripped_bytes, kind, callback)
+					if r1 ~= nil then return r1, r2, r3, r4 end
+				end
+			end
+		end
+		return nil
+	end
+
+	for _, p in ipairs(Conjugations.noun_suffixes) do
+		if #term > #p and term:sub(-#p) == p then
+			local stripped = term:sub(1, -(#p + 1))
+			if #stripped >= 3 then
+				local r1, r2, r3, r4 = callback_deconjugated_base(stripped, #p, "suffix_strip", callback)
+				if r1 ~= nil then return r1, r2, r3, r4 end
+			end
+		end
+	end
+
+	for _, adj in ipairs(Conjugations.adj_endings) do
+		local p = adj.ending
+		if #term > #p and term:sub(-#p) == p then
+			local stripped = term:sub(1, -(#p + 1)) .. adj.rep
+			if #stripped >= 3 and not Conjugations.is_invalid_adj_base(term, stripped) then
+				local match_strip_bytes = p:sub(-#"です") == "です" and #"です" or 0
+				local match_kind = match_strip_bytes > 0 and "suffix_strip" or "inflection"
+				local r1, r2, r3, r4 =
+					callback_deconjugated_base(stripped, match_strip_bytes, match_kind, callback)
+				if r1 ~= nil then return r1, r2, r3, r4 end
+			end
+		end
+	end
+
+	for _, p in ipairs(Conjugations.na_adj_endings) do
+		if #term > #p and term:sub(-#p) == p then
+			local stripped = term:sub(1, -(#p + 1))
+			if #stripped >= 3 then
+				local r1, r2, r3, r4 = callback_deconjugated_base(stripped, #p, "suffix_strip", callback)
+				if r1 ~= nil then return r1, r2, r3, r4 end
+			end
+		end
+	end
+
+	for _, suffix in ipairs(Conjugations.verb_particle_suffixes or {}) do
+		if #term > #suffix and term:sub(-#suffix) == suffix then
+			local stripped_surface = term:sub(1, -(#suffix + 1))
+			local r1, r2, r3, r4 = try_verb_rules(stripped_surface, #suffix, "suffix_strip")
+			if r1 ~= nil then return r1, r2, r3, r4 end
+		end
+	end
+
+	return try_verb_rules(term, 0, "inflection")
+end
+
+function Conjugations.each_kana_adj_reading_term(term, opts, callback)
+	if type(opts) == "function" and callback == nil then
+		callback = opts
+		opts = {}
+	end
+	opts = opts or {}
+
+	if type(term) ~= "string" or term == "" then
+		return nil
+	end
+
+	local is_kana_only_fn = opts.is_kana_only or function() return false end
+
+	for _, adj in ipairs(Conjugations.adj_endings) do
+		local p = adj.ending
+		if #term > #p and term:sub(-#p) == p then
+			local stripped = term:sub(1, -(#p + 1)) .. adj.rep
+			if #stripped >= 3
+				and is_kana_only_fn(stripped)
+				and Conjugations.is_invalid_adj_base(term, stripped) then
+				local r1, r2, r3, r4 = callback(stripped, 0, "inflection")
+				if r1 ~= nil then return r1, r2, r3, r4 end
+			end
+		end
+	end
+
+	return nil
 end
 
 local na_adj_endings = {
@@ -185,6 +321,8 @@ sort_string_rules(na_adj_endings)
 Conjugations.na_adj_endings = na_adj_endings
 
 local verb_endings = {
+	{ ending = "来た", rep = "来る" },
+	{ ending = "来て", rep = "来る" },
 	{ ending = "いたくなかった", rep = "う" },
 	{ ending = "いませんでした", rep = "う" },
 	{ ending = "きたくなかった", rep = "く" },
@@ -211,19 +349,27 @@ local verb_endings = {
 	{ ending = "いてしまって", rep = "く" },
 	{ ending = "いでしまった", rep = "ぐ" },
 	{ ending = "いでしまって", rep = "ぐ" },
+	{ ending = "いじゃなかった", rep = "ぐ" },
+	{ ending = "いじゃったら", rep = "ぐ" },
+	{ ending = "いじゃった", rep = "ぐ" },
+	{ ending = "いじゃって", rep = "ぐ" },
 	{ ending = "かせなかった", rep = "く" },
+	{ ending = "かせて", rep = "く" },
 	{ ending = "かなかったら", rep = "く" },
 	{ ending = "かれなかった", rep = "く" },
 	{ ending = "がせなかった", rep = "ぐ" },
+	{ ending = "がせて", rep = "ぐ" },
 	{ ending = "がなかったら", rep = "ぐ" },
 	{ ending = "がれなかった", rep = "ぐ" },
 	{ ending = "させなかった", rep = "す" },
+	{ ending = "させて", rep = "す" },
 	{ ending = "さなかったら", rep = "す" },
 	{ ending = "されなかった", rep = "す" },
 	{ ending = "してしまった", rep = "す" },
 	{ ending = "してしまって", rep = "す" },
 	{ ending = "たくなかった", rep = "る" },
 	{ ending = "たせなかった", rep = "つ" },
+	{ ending = "たせて", rep = "つ" },
 	{ ending = "たなかったら", rep = "つ" },
 	{ ending = "たれなかった", rep = "つ" },
 	{ ending = "ってしまった", rep = "う" },
@@ -233,21 +379,32 @@ local verb_endings = {
 	{ ending = "ってしまって", rep = "つ" },
 	{ ending = "ってしまって", rep = "る" },
 	{ ending = "なせなかった", rep = "ぬ" },
+	{ ending = "なせて", rep = "ぬ" },
 	{ ending = "ななかったら", rep = "ぬ" },
 	{ ending = "なれなかった", rep = "ぬ" },
 	{ ending = "ばせなかった", rep = "ぶ" },
+	{ ending = "ばせて", rep = "ぶ" },
 	{ ending = "ばなかったら", rep = "ぶ" },
 	{ ending = "ばれなかった", rep = "ぶ" },
 	{ ending = "ませなかった", rep = "む" },
+	{ ending = "ませて", rep = "む" },
 	{ ending = "ませんでした", rep = "る" },
 	{ ending = "まなかったら", rep = "む" },
 	{ ending = "まれなかった", rep = "む" },
 	{ ending = "らせなかった", rep = "る" },
 	{ ending = "らなかったら", rep = "る" },
 	{ ending = "られなかった", rep = "る" },
+	{ ending = "らせて", rep = "る" },
+	{ ending = "らせる", rep = "る" },
+	{ ending = "らせた", rep = "る" },
 	{ ending = "わせなかった", rep = "う" },
+	{ ending = "わせて", rep = "う" },
 	{ ending = "わなかったら", rep = "う" },
 	{ ending = "われなかった", rep = "う" },
+	{ ending = "われていた", rep = "う" },
+	{ ending = "われている", rep = "う" },
+	{ ending = "われてた", rep = "う" },
+	{ ending = "われてる", rep = "う" },
 	{ ending = "んでしまった", rep = "ぬ" },
 	{ ending = "んでしまった", rep = "ぶ" },
 	{ ending = "んでしまった", rep = "む" },
@@ -265,6 +422,7 @@ local verb_endings = {
 	{ ending = "いてしまう", rep = "く" },
 	{ ending = "いでおいた", rep = "ぐ" },
 	{ ending = "いでしまう", rep = "ぐ" },
+	{ ending = "いじゃう", rep = "ぐ" },
 	{ ending = "いましたら", rep = "う" },
 	{ ending = "えなかった", rep = "う" },
 	{ ending = "かなかった", rep = "く" },
@@ -378,6 +536,7 @@ local verb_endings = {
 	{ ending = "いまして", rep = "う" },
 	{ ending = "いません", rep = "う" },
 	{ ending = "いません", rep = "る" },
+	{ ending = "いましょう", rep = "う" },
 	{ ending = "いやがる", rep = "う" },
 	{ ending = "かせない", rep = "く" },
 	{ ending = "かないで", rep = "く" },
@@ -397,12 +556,15 @@ local verb_endings = {
 	{ ending = "きまして", rep = "く" },
 	{ ending = "きません", rep = "く" },
 	{ ending = "きません", rep = "くる" },
+	{ ending = "きましょう", rep = "く" },
+	{ ending = "きましょう", rep = "くる" },
 	{ ending = "きやがる", rep = "く" },
 	{ ending = "ぎたくて", rep = "ぐ" },
 	{ ending = "ぎなさい", rep = "ぐ" },
 	{ ending = "ぎました", rep = "ぐ" },
 	{ ending = "ぎまして", rep = "ぐ" },
 	{ ending = "ぎません", rep = "ぐ" },
+	{ ending = "ぎましょう", rep = "ぐ" },
 	{ ending = "ぎやがる", rep = "ぐ" },
 	{ ending = "こさせる", rep = "くる" },
 	{ ending = "こなくて", rep = "くる" },
@@ -424,6 +586,11 @@ local verb_endings = {
 	{ ending = "してから", rep = "する" },
 	{ ending = "してきた", rep = "す" },
 	{ ending = "してくる", rep = "す" },
+	{ ending = "しといた", rep = "する" },
+	{ ending = "しといて", rep = "する" },
+	{ ending = "しとく", rep = "する" },
+	{ ending = "しとけ", rep = "する" },
+	{ ending = "しとこう", rep = "する" },
 	{ ending = "してたら", rep = "す" },
 	{ ending = "してたら", rep = "する" },
 	{ ending = "してたり", rep = "す" },
@@ -436,10 +603,13 @@ local verb_endings = {
 	{ ending = "しまして", rep = "する" },
 	{ ending = "しません", rep = "す" },
 	{ ending = "しません", rep = "する" },
+	{ ending = "しましょう", rep = "す" },
+	{ ending = "しましょう", rep = "する" },
 	{ ending = "しやがる", rep = "す" },
 	{ ending = "たかった", rep = "る" },
 	{ ending = "たくって", rep = "る" },
 	{ ending = "たくない", rep = "る" },
+	{ ending = "れちゃった", rep = "る" },
 	{ ending = "たせない", rep = "つ" },
 	{ ending = "たないで", rep = "つ" },
 	{ ending = "たなくて", rep = "つ" },
@@ -449,11 +619,21 @@ local verb_endings = {
 	{ ending = "ちました", rep = "つ" },
 	{ ending = "ちまして", rep = "つ" },
 	{ ending = "ちません", rep = "つ" },
+	{ ending = "ちましょう", rep = "つ" },
 	{ ending = "ちゃった", rep = "る" },
 	{ ending = "ちやがる", rep = "つ" },
 	{ ending = "ったって", rep = "う" },
 	{ ending = "ったって", rep = "つ" },
 	{ ending = "ったって", rep = "る" },
+	{ ending = "っちゃった", rep = "う" },
+	{ ending = "っちゃった", rep = "つ" },
+	{ ending = "っちゃった", rep = "る" },
+	{ ending = "っちゃって", rep = "う" },
+	{ ending = "っちゃって", rep = "つ" },
+	{ ending = "っちゃって", rep = "る" },
+	{ ending = "っちゃう", rep = "う" },
+	{ ending = "っちゃう", rep = "つ" },
+	{ ending = "っちゃう", rep = "る" },
 	{ ending = "っていく", rep = "う" },
 	{ ending = "っていく", rep = "つ" },
 	{ ending = "っていく", rep = "る" },
@@ -494,6 +674,7 @@ local verb_endings = {
 	{ ending = "にました", rep = "ぬ" },
 	{ ending = "にまして", rep = "ぬ" },
 	{ ending = "にません", rep = "ぬ" },
+	{ ending = "にましょう", rep = "ぬ" },
 	{ ending = "にやがる", rep = "ぬ" },
 	{ ending = "ばせない", rep = "ぶ" },
 	{ ending = "ばないで", rep = "ぶ" },
@@ -504,6 +685,7 @@ local verb_endings = {
 	{ ending = "びました", rep = "ぶ" },
 	{ ending = "びまして", rep = "ぶ" },
 	{ ending = "びません", rep = "ぶ" },
+	{ ending = "びましょう", rep = "ぶ" },
 	{ ending = "びやがる", rep = "ぶ" },
 	{ ending = "ませない", rep = "む" },
 	{ ending = "まないで", rep = "む" },
@@ -514,6 +696,7 @@ local verb_endings = {
 	{ ending = "みました", rep = "む" },
 	{ ending = "みまして", rep = "む" },
 	{ ending = "みません", rep = "む" },
+	{ ending = "みましょう", rep = "む" },
 	{ ending = "みやがる", rep = "む" },
 	{ ending = "らせない", rep = "る" },
 	{ ending = "らないで", rep = "る" },
@@ -524,6 +707,7 @@ local verb_endings = {
 	{ ending = "りました", rep = "る" },
 	{ ending = "りまして", rep = "る" },
 	{ ending = "りません", rep = "る" },
+	{ ending = "りましょう", rep = "る" },
 	{ ending = "りやがる", rep = "る" },
 	{ ending = "わせない", rep = "う" },
 	{ ending = "わないで", rep = "う" },
@@ -572,27 +756,25 @@ local verb_endings = {
 	{ ending = "いって", rep = "いく" },
 	{ ending = "いてた", rep = "く" },
 	{ ending = "いては", rep = "く" },
-	{ ending = "いても", rep = "く" },
 	{ ending = "いてる", rep = "く" },
 	{ ending = "いでた", rep = "ぐ" },
 	{ ending = "いでは", rep = "ぐ" },
-	{ ending = "いでも", rep = "ぐ" },
 	{ ending = "いでる", rep = "ぐ" },
 	{ ending = "います", rep = "う" },
 	{ ending = "います", rep = "る" },
 	{ ending = "いませ", rep = "る" },
 	{ ending = "えない", rep = "う" },
 	{ ending = "かなきゃ", rep = "く" },
+	{ ending = "かなければ", rep = "く" },
 	{ ending = "かなくちゃ", rep = "く" },
-	{ ending = "かずに", rep = "く" },
 	{ ending = "かせた", rep = "く" },
 	{ ending = "かせる", rep = "く" },
 	{ ending = "かない", rep = "く" },
 	{ ending = "かれた", rep = "く" },
 	{ ending = "かれる", rep = "く" },
 	{ ending = "がなきゃ", rep = "ぐ" },
+	{ ending = "がなければ", rep = "ぐ" },
 	{ ending = "がなくちゃ", rep = "ぐ" },
-	{ ending = "がずに", rep = "ぐ" },
 	{ ending = "がせた", rep = "ぐ" },
 	{ ending = "がせる", rep = "ぐ" },
 	{ ending = "がない", rep = "ぐ" },
@@ -602,7 +784,6 @@ local verb_endings = {
 	{ ending = "きたら", rep = "くる" },
 	{ ending = "きたり", rep = "くる" },
 	{ ending = "きてた", rep = "くる" },
-	{ ending = "きても", rep = "くる" },
 	{ ending = "きてる", rep = "くる" },
 	{ ending = "きます", rep = "く" },
 	{ ending = "きます", rep = "くる" },
@@ -612,15 +793,18 @@ local verb_endings = {
 	{ ending = "けない", rep = "く" },
 	{ ending = "げない", rep = "ぐ" },
 	{ ending = "こなきゃ", rep = "くる" },
+	{ ending = "こなければ", rep = "くる" },
 	{ ending = "こなくちゃ", rep = "くる" },
 	{ ending = "こない", rep = "くる" },
 	{ ending = "こよう", rep = "くる" },
 	{ ending = "さなきゃ", rep = "す" },
+	{ ending = "さなければ", rep = "す" },
 	{ ending = "さなくちゃ", rep = "す" },
-	{ ending = "さずに", rep = "す" },
 	{ ending = "させた", rep = "す" },
 	{ ending = "させた", rep = "する" },
+	{ ending = "させて", rep = "する" },
 	{ ending = "させた", rep = "る" },
+	{ ending = "させて", rep = "る" },
 	{ ending = "させて", rep = "する" },
 	{ ending = "させる", rep = "す" },
 	{ ending = "させる", rep = "する" },
@@ -642,11 +826,11 @@ local verb_endings = {
 	{ ending = "してた", rep = "する" },
 	{ ending = "しては", rep = "す" },
 	{ ending = "しては", rep = "する" },
-	{ ending = "しても", rep = "す" },
-	{ ending = "しても", rep = "する" },
 	{ ending = "してる", rep = "す" },
 	{ ending = "してる", rep = "する" },
 	{ ending = "しなきゃ", rep = "する" },
+	{ ending = "しなければ", rep = "す" },
+	{ ending = "しなければ", rep = "する" },
 	{ ending = "しなくちゃ", rep = "する" },
 	{ ending = "しない", rep = "する" },
 	{ ending = "します", rep = "す" },
@@ -657,8 +841,8 @@ local verb_endings = {
 	{ ending = "せない", rep = "す" },
 	{ ending = "たくて", rep = "る" },
 	{ ending = "たなきゃ", rep = "つ" },
+	{ ending = "たなければ", rep = "つ" },
 	{ ending = "たなくちゃ", rep = "つ" },
-	{ ending = "たずに", rep = "つ" },
 	{ ending = "たせた", rep = "つ" },
 	{ ending = "たせる", rep = "つ" },
 	{ ending = "たって", rep = "る" },
@@ -680,9 +864,6 @@ local verb_endings = {
 	{ ending = "っては", rep = "う" },
 	{ ending = "っては", rep = "つ" },
 	{ ending = "っては", rep = "る" },
-	{ ending = "っても", rep = "う" },
-	{ ending = "っても", rep = "つ" },
-	{ ending = "っても", rep = "る" },
 	{ ending = "ってる", rep = "う" },
 	{ ending = "ってる", rep = "つ" },
 	{ ending = "ってる", rep = "る" },
@@ -695,13 +876,14 @@ local verb_endings = {
 	{ ending = "てたら", rep = "る" },
 	{ ending = "てない", rep = "つ" },
 	{ ending = "なきゃ", rep = "る" },
+	{ ending = "なければ", rep = "る" },
 	{ ending = "なくちゃ", rep = "る" },
 	{ ending = "ないで", rep = "る" },
 	{ ending = "なくて", rep = "る" },
 	{ ending = "なさい", rep = "る" },
 	{ ending = "ななきゃ", rep = "ぬ" },
+	{ ending = "ななければ", rep = "ぬ" },
 	{ ending = "ななくちゃ", rep = "ぬ" },
-	{ ending = "なずに", rep = "ぬ" },
 	{ ending = "なせた", rep = "ぬ" },
 	{ ending = "なせる", rep = "ぬ" },
 	{ ending = "なない", rep = "ぬ" },
@@ -711,8 +893,8 @@ local verb_endings = {
 	{ ending = "にます", rep = "ぬ" },
 	{ ending = "ねない", rep = "ぬ" },
 	{ ending = "ばなきゃ", rep = "ぶ" },
+	{ ending = "ばなければ", rep = "ぶ" },
 	{ ending = "ばなくちゃ", rep = "ぶ" },
-	{ ending = "ばずに", rep = "ぶ" },
 	{ ending = "ばせた", rep = "ぶ" },
 	{ ending = "ばせる", rep = "ぶ" },
 	{ ending = "ばない", rep = "ぶ" },
@@ -724,8 +906,8 @@ local verb_endings = {
 	{ ending = "ました", rep = "る" },
 	{ ending = "まして", rep = "る" },
 	{ ending = "まなきゃ", rep = "む" },
+	{ ending = "まなければ", rep = "む" },
 	{ ending = "まなくちゃ", rep = "む" },
-	{ ending = "まずに", rep = "む" },
 	{ ending = "ませた", rep = "む" },
 	{ ending = "ませる", rep = "む" },
 	{ ending = "ません", rep = "る" },
@@ -736,19 +918,21 @@ local verb_endings = {
 	{ ending = "みます", rep = "む" },
 	{ ending = "めない", rep = "む" },
 	{ ending = "らなきゃ", rep = "る" },
+	{ ending = "らなければ", rep = "る" },
 	{ ending = "らなくちゃ", rep = "る" },
-	{ ending = "らずに", rep = "る" },
 	{ ending = "らせた", rep = "る" },
 	{ ending = "らせる", rep = "る" },
 	{ ending = "らない", rep = "る" },
 	{ ending = "られた", rep = "る" },
 	{ ending = "られる", rep = "る" },
+	{ ending = "られなく", rep = "る" },
 	{ ending = "りたい", rep = "る" },
 	{ ending = "ります", rep = "る" },
 	{ ending = "れない", rep = "る" },
+	{ ending = "れなく", rep = "る" },
 	{ ending = "わなきゃ", rep = "う" },
+	{ ending = "わなければ", rep = "う" },
 	{ ending = "わなくちゃ", rep = "う" },
-	{ ending = "わずに", rep = "う" },
 	{ ending = "わせた", rep = "う" },
 	{ ending = "わせる", rep = "う" },
 	{ ending = "わない", rep = "う" },
@@ -766,13 +950,11 @@ local verb_endings = {
 	{ ending = "んでは", rep = "ぬ" },
 	{ ending = "んでは", rep = "ぶ" },
 	{ ending = "んでは", rep = "む" },
-	{ ending = "んでも", rep = "ぬ" },
-	{ ending = "んでも", rep = "ぶ" },
-	{ ending = "んでも", rep = "む" },
 	{ ending = "んでる", rep = "ぬ" },
 	{ ending = "んでる", rep = "ぶ" },
 	{ ending = "んでる", rep = "む" },
 	{ ending = "いき", rep = "いく" },
+	{ ending = "え", rep = "う", kanji_surface_only = true },
 	{ ending = "いた", rep = "く" },
 	{ ending = "いだ", rep = "ぐ" },
 	{ ending = "いて", rep = "く" },
@@ -804,7 +986,6 @@ local verb_endings = {
 	{ ending = "して", rep = "する" },
 	{ ending = "しよ", rep = "する" },
 	{ ending = "しろ", rep = "する" },
-	{ ending = "ずに", rep = "る" },
 	{ ending = "せず", rep = "する" },
 	{ ending = "せた", rep = "す" },
 	{ ending = "せて", rep = "す" },
@@ -814,6 +995,7 @@ local verb_endings = {
 	{ ending = "そう", rep = "す" },
 	{ ending = "たい", rep = "る" },
 	{ ending = "たず", rep = "つ" },
+	{ ending = "た", rep = "る" },
 	{ ending = "たら", rep = "る" },
 	{ ending = "たり", rep = "る" },
 	{ ending = "ちゃ", rep = "る" },
@@ -826,9 +1008,9 @@ local verb_endings = {
 	{ ending = "てた", rep = "つ" },
 	{ ending = "てた", rep = "る" },
 	{ ending = "てて", rep = "つ" },
+	{ ending = "て", rep = "る" },
 	{ ending = "ては", rep = "る" },
 	{ ending = "てば", rep = "つ" },
-	{ ending = "ても", rep = "る" },
 	{ ending = "てる", rep = "つ" },
 	{ ending = "てる", rep = "る" },
 	{ ending = "とう", rep = "つ" },
@@ -867,22 +1049,6 @@ local verb_endings = {
 	{ ending = "んで", rep = "ぬ" },
 	{ ending = "んで", rep = "ぶ" },
 	{ ending = "んで", rep = "む" },
-	{ ending = "い", rep = "う" },
-	{ ending = "き", rep = "く" },
-	{ ending = "き", rep = "くる" },
-	{ ending = "ぎ", rep = "ぐ" },
-	{ ending = "し", rep = "す" },
-	{ ending = "し", rep = "する" },
-	{ ending = "ず", rep = "る" },
-	{ ending = "た", rep = "る" },
-	{ ending = "ち", rep = "つ" },
-	{ ending = "て", rep = "る" },
-	{ ending = "に", rep = "ぬ" },
-	{ ending = "び", rep = "ぶ" },
-	{ ending = "み", rep = "む" },
-	{ ending = "よ", rep = "る" },
-	{ ending = "り", rep = "る" },
-	{ ending = "ろ", rep = "る" },
 }
 sort_pair_rules(verb_endings)
 Conjugations.verb_endings = verb_endings

--- a/scripts/yomipv/lib/json_format.lua
+++ b/scripts/yomipv/lib/json_format.lua
@@ -4,6 +4,35 @@ local utils = require("mp.utils")
 
 local JSONFormat = {}
 
+local function get_priority(keys)
+	if keys.generated_at or keys.fields or keys.words then
+		return { generated_at = 1, fields = 2, words = 3 }
+	end
+
+	if keys.interval or keys.state or keys.reading then
+		return { reading = 1, interval = 2, state = 3 }
+	end
+
+	return {}
+end
+
+local function is_scalar(value)
+	return type(value) == "string" or type(value) == "number" or type(value) == "boolean" or value == nil
+end
+
+local function is_scalar_array(obj)
+	if type(obj) ~= "table" or #obj == 0 then
+		return false
+	end
+
+	for _, value in ipairs(obj) do
+		if not is_scalar(value) then
+			return false
+		end
+	end
+	return true
+end
+
 function JSONFormat.format(obj, level)
 	level = level or 0
 	local indent = string.rep("  ", level)
@@ -13,23 +42,36 @@ function JSONFormat.format(obj, level)
 		local is_array = #obj > 0
 		local parts = {}
 		if is_array then
-			table.insert(parts, "[\n")
-			for i, v in ipairs(obj) do
-				table.insert(parts, next_indent .. JSONFormat.format(v, level + 1))
-				if i < #obj then
-					table.insert(parts, ",")
+			if is_scalar_array(obj) then
+				table.insert(parts, "[")
+				for i, v in ipairs(obj) do
+					table.insert(parts, JSONFormat.format(v, 0))
+					if i < #obj then
+						table.insert(parts, ", ")
+					end
 				end
-				table.insert(parts, "\n")
+				table.insert(parts, "]")
+			else
+				table.insert(parts, "[\n")
+				for i, v in ipairs(obj) do
+					table.insert(parts, next_indent .. JSONFormat.format(v, level + 1))
+					if i < #obj then
+						table.insert(parts, ",")
+					end
+					table.insert(parts, "\n")
+				end
+				table.insert(parts, indent .. "]")
 			end
-			table.insert(parts, indent .. "]")
 		else
 			table.insert(parts, "{\n")
 			local keys = {}
+			local key_set = {}
 			for k in pairs(obj) do
 				table.insert(keys, k)
+				key_set[k] = true
 			end
 
-			local priority = { generated_at = 1, fields = 2, words = 3 }
+			local priority = get_priority(key_set)
 			table.sort(keys, function(a, b)
 				if priority[a] and priority[b] then return priority[a] < priority[b] end
 				if priority[a] then return true end

--- a/scripts/yomipv/lib/launcher.lua
+++ b/scripts/yomipv/lib/launcher.lua
@@ -7,6 +7,7 @@ local utils = require("mp.utils")
 local Platform = require("lib.platform")
 
 local Launcher = {}
+local shutdown_sent = false
 
 function Launcher.launch_lookup_app(_config)
 	local app_path = "lookup-app"
@@ -69,6 +70,11 @@ function Launcher.launch_lookup_app(_config)
 end
 
 function Launcher.shutdown_lookup_app()
+	if shutdown_sent then
+		return
+	end
+	shutdown_sent = true
+
 	msg.info("Sending shutdown signal to lookup app")
 	local ok, result = pcall(mp.command_native, {
 		name = "subprocess",

--- a/scripts/yomipv/lib/platform.lua
+++ b/scripts/yomipv/lib/platform.lua
@@ -77,9 +77,6 @@ end
 -- Launcher implementation for Electron frontend
 function Platform.launch_electron_app(app_path, mpv_pid, ipc_pipe, callback)
 	local binary_name = "YomipvLookup" .. Platform.get_binary_extension()
-	if Platform.IS_LINUX then
-		binary_name = "YomipvLookup.AppImage"
-	end
 
 	local root_dir = mp.get_script_directory() .. "/"
 	local binary_path
@@ -88,6 +85,10 @@ function Platform.launch_electron_app(app_path, mpv_pid, ipc_pipe, callback)
 		-- Resolve executable paths within .app bundles
 		local app_bundle = Platform.normalize_path(utils.join_path(root_dir, "YomipvLookup.app"))
 		binary_path = app_bundle .. "/Contents/MacOS/YomipvLookup"
+	elseif Platform.IS_WINDOWS then
+		binary_path = Platform.normalize_path(utils.join_path(root_dir, "YomipvLookup\\" .. binary_name))
+	elseif Platform.IS_LINUX then
+		binary_path = Platform.normalize_path(utils.join_path(root_dir, "YomipvLookup/" .. binary_name))
 	else
 		binary_path = Platform.normalize_path(utils.join_path(root_dir, binary_name))
 	end

--- a/scripts/yomipv/lib/string_ops.lua
+++ b/scripts/yomipv/lib/string_ops.lua
@@ -195,6 +195,8 @@ function StringOps.clean_title(title, path)
 
 	-- Strip season, episode, and version tags
 	local cleaner_patterns = {
+		"[%s%.%-%_]+[Ee][Pp][Ii][Ss][Oo][Dd][Ee]%s*%d+.*$",
+		"[%s%.%-%_]+[Ee][Pp]?%s*%d+.*$",
 		"[%.%s_]+[Ss]%d+[Ee]%d+",
 		"[%.%s_]+[Ee]%d+",
 		"[%.%s_]+[Ss]eason%s*%d+",
@@ -232,7 +234,8 @@ function StringOps.parse_season_episode(title, path)
 
 	-- Fallback for compact 4-digit blocks
 	if not season then
-		local block = source:match("[Ss](%d%d%d%d)")
+		local block = source:match("^[Ss](%d%d%d%d)")
+			or source:match("[ _%.%-%[%(%{][Ss](%d%d%d%d)")
 		if block then
 			season = block:sub(1, 2)
 			episode = block:sub(3, 4)
@@ -277,7 +280,9 @@ function StringOps.parse_season_episode(title, path)
 
 	-- Independent episode detection
 	if not episode then
-		episode = source:match("[ _%.%-][Ee][Pp]?%s*(%d+)")
+		episode = source:match("[ _%.%-][Ee][Pp][Ii][Ss][Oo][Dd][Ee]%s*(%d+)")
+			or source:match("^[Ee][Pp][Ii][Ss][Oo][Dd][Ee]%s*(%d+)")
+			or source:match("[ _%.%-][Ee][Pp]?%s*(%d+)")
 			or source:match("^[Ee][Pp]?%s*(%d+)")
 			-- Trailing number that isn't part of a season tag
 			or source:match("[ _%.%-](%d+)[^0-9]*$")

--- a/scripts/yomipv/lib/string_ops.lua
+++ b/scripts/yomipv/lib/string_ops.lua
@@ -7,6 +7,7 @@ local StringOps = {}
 local CONTROL_CHARS_PATTERN = "[\1-\31\127]"
 local WHITESPACE_PATTERN = "[ \t\n\r]+"
 local SUBTITLE_TAGS_PATTERN = "{[^}]-}"
+local HTML_TAGS_PATTERN = "<[^>]->"
 local SUBTITLE_SYMBOLS = { "🔊", "➨", "➡", "➔", "➜", "➝", "➞" }
 local BRACKET_PATTERNS = {
 	"（.-）", -- Full-width
@@ -38,13 +39,13 @@ function StringOps.clean_text(text, preserve_newlines)
 	return cleaned
 end
 
--- Strips ASS tags and symbols from subtitle text
+-- Strips ASS/HTML subtitle styling tags and symbols from subtitle text
 function StringOps.clean_subtitle(text, preserve_newlines)
 	if not text or text == "" then
 		return ""
 	end
 
-	local cleaned = text:gsub(SUBTITLE_TAGS_PATTERN, "")
+	local cleaned = text:gsub(SUBTITLE_TAGS_PATTERN, ""):gsub(HTML_TAGS_PATTERN, "")
 
 	-- Strip symbols individually to avoid UTF-8 bracketed set issues
 	for _, symbol in ipairs(SUBTITLE_SYMBOLS) do
@@ -427,11 +428,18 @@ end
 
 function StringOps.count_shared_prefix(a, b)
 	if not a or not b then return 0 end
+	local function normalize_kana(code)
+		if code >= 0x30A1 and code <= 0x30FA then
+			return code - 0x60
+		end
+		return code
+	end
+
 	local shared = 0
 	local iter_b, state_b, cur_b = StringOps.utf8_codes(b)
 	for _, code_a in StringOps.utf8_codes(a) do
 		local n_b, code_b = iter_b(state_b, cur_b)
-		if not n_b or code_a ~= code_b then
+		if not n_b or normalize_kana(code_a) ~= normalize_kana(code_b) then
 			break
 		end
 		shared = shared + 1

--- a/scripts/yomipv/lookup-app/history.css
+++ b/scripts/yomipv/lookup-app/history.css
@@ -74,7 +74,7 @@ body.visible #history-container {
 .header-actions {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .header-actions button {
@@ -90,20 +90,12 @@ body.visible #history-container {
   white-space: nowrap;
 }
 
-.header-actions button:hover,
-.header-actions button.active {
+.header-actions button:hover {
   color: #ffffff;
 }
 
-.header-dropdown {
-  position: relative;
-}
-
-[hidden] {
-  display: none !important;
-}
-
-#history-menu-toggle,
+.header-icon-button,
+#clear-history,
 #open-settings {
   min-width: 30px;
   height: 30px;
@@ -114,28 +106,19 @@ body.visible #history-container {
   padding: 0 8px;
 }
 
-#history-menu-toggle {
-  padding: 0;
+#clear-history svg,
+.header-icon-button svg {
+  width: 18px;
+  height: 18px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
-.menu-dots {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 3px;
-  height: 100%;
-}
-
-.menu-dot {
-  width: 4px;
-  height: 4px;
-  border-radius: 999px;
-  background-color: currentColor;
-  display: block;
-}
-
-#history-menu-toggle:hover,
-#history-menu-toggle.active,
+.header-icon-button:hover,
+#clear-history:hover,
 #open-settings:hover {
   background-color: rgba(255, 255, 255, 0.08);
 }
@@ -144,33 +127,34 @@ body.visible #history-container {
   font-size: 18px;
 }
 
-.history-menu {
+.header-icon-button {
+  position: relative;
+}
+
+.state-slash {
   position: absolute;
-  top: calc(100% + 8px);
-  right: 0;
-  min-width: 154px;
-  padding: 6px;
-  border-radius: 12px;
-  background: color-mix(in srgb, var(--bg-color-hex), #181818 40%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.45);
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  z-index: 20;
+  width: 20px;
+  height: 2px;
+  border-radius: 999px;
+  background-color: currentColor;
+  transform: rotate(-42deg);
+  opacity: 0.9;
 }
 
-.history-menu button {
-  width: 100%;
-  min-height: 34px;
-  padding: 0 12px;
-  border-radius: 8px;
-  text-align: left;
-  letter-spacing: 0.6px;
+#anim-toggle.active .state-slash {
+  opacity: 0;
 }
 
-.history-menu button:hover {
-  background-color: rgba(255, 255, 255, 0.08);
+.icon-current-pos {
+  display: none;
+}
+
+.time-current .icon-sub-start {
+  display: none;
+}
+
+.time-current .icon-current-pos {
+  display: block;
 }
 
 #history-scroll-clip {

--- a/scripts/yomipv/lookup-app/history.html
+++ b/scripts/yomipv/lookup-app/history.html
@@ -10,20 +10,43 @@
     <div id="history-header">
       <span id="header-title">HISTORY</span>
       <div class="header-actions">
-        <div class="header-dropdown">
-          <button id="history-menu-toggle" aria-label="History actions" aria-expanded="false">
-            <span class="menu-dots" aria-hidden="true">
-              <span class="menu-dot"></span>
-              <span class="menu-dot"></span>
-              <span class="menu-dot"></span>
-            </span>
-          </button>
-          <div id="history-menu" class="history-menu" hidden>
-            <button id="time-toggle">SUB START</button>
-            <button id="anim-toggle">GIF: OFF</button>
-            <button id="clear-history">CLEAR</button>
-          </div>
-        </div>
+        <button id="time-toggle" class="header-icon-button" aria-label="Subtitle start" title="Subtitle start">
+          <svg class="icon-sub-start" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="4" y="5" width="16" height="14" rx="2"></rect>
+            <path d="M8 15h5"></path>
+            <path d="M8 11h8"></path>
+            <path d="M6 3v18"></path>
+          </svg>
+          <svg class="icon-current-pos" viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="6"></circle>
+            <path d="M12 3v3"></path>
+            <path d="M12 18v3"></path>
+            <path d="M3 12h3"></path>
+            <path d="M18 12h3"></path>
+            <circle cx="12" cy="12" r="1.5"></circle>
+          </svg>
+        </button>
+        <button id="anim-toggle" class="header-icon-button" aria-label="GIF off" title="GIF off">
+          <svg class="icon-film" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="4" y="5" width="16" height="14" rx="2"></rect>
+            <path d="M8 5v14"></path>
+            <path d="M16 5v14"></path>
+            <path d="M4 9h4"></path>
+            <path d="M16 9h4"></path>
+            <path d="M4 15h4"></path>
+            <path d="M16 15h4"></path>
+          </svg>
+          <span class="state-slash" aria-hidden="true"></span>
+        </button>
+        <button id="clear-history" aria-label="Clear history" title="Clear history">
+          <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M3 6h18"></path>
+            <path d="M8 6V4h8v2"></path>
+            <path d="M6 6l1 15h10l1-15"></path>
+            <path d="M10 10v7"></path>
+            <path d="M14 10v7"></path>
+          </svg>
+        </button>
         <button id="open-settings" aria-label="Open settings">&#9881;</button>
       </div>
     </div>

--- a/scripts/yomipv/lookup-app/history.js
+++ b/scripts/yomipv/lookup-app/history.js
@@ -3,8 +3,6 @@ const { ipcRenderer } = require('electron');
 const listContainer = document.getElementById('history-list');
 const scrollClip = document.getElementById('history-scroll-clip');
 const headerTitle = document.getElementById('header-title');
-const menuToggle = document.getElementById('history-menu-toggle');
-const menu = document.getElementById('history-menu');
 const animToggle = document.getElementById('anim-toggle');
 const timeToggle = document.getElementById('time-toggle');
 const settingsBtn = document.getElementById('open-settings');
@@ -14,7 +12,6 @@ let isAppending = false;
 let canExpand = false;
 let autoScroll = true;
 let prevIsAppending = false;
-let isMenuOpen = false;
 
 const container = document.getElementById('history-container');
 
@@ -36,34 +33,12 @@ document.addEventListener('selectionchange', () => {
   }
 });
 
-document.addEventListener('click', (e) => {
-  if (!isMenuOpen) {
-    return;
-  }
-  if (!menu.contains(e.target) && e.target !== menuToggle) {
-    setMenuOpen(false);
-  }
-});
-
-document.addEventListener('keydown', (e) => {
-  if (e.key === 'Escape' && isMenuOpen) {
-    setMenuOpen(false);
-  }
-});
-
 const handleCopy = () => {
   const selection = window.getSelection().toString();
   if (selection) {
     require('electron').clipboard.writeText(selection);
     window.getSelection().removeAllRanges();
   }
-};
-
-const setMenuOpen = (open) => {
-  isMenuOpen = open;
-  menu.hidden = !open;
-  menuToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
-  menuToggle.classList.toggle('active', open);
 };
 
 document.addEventListener('copy', (e) => {
@@ -132,10 +107,16 @@ ipcRenderer.on('update-history', (event, payload) => {
   headerTitle.textContent = isAppending ? 'SELECTED' : 'HISTORY';
 
   if (config) {
-    animToggle.textContent = config.picture_animated ? 'GIF: ON' : 'GIF: OFF';
+    const gifOn = !!config.picture_animated;
+    animToggle.classList.toggle('active', gifOn);
+    animToggle.setAttribute('aria-label', gifOn ? 'GIF on' : 'GIF off');
+    animToggle.title = gifOn ? 'GIF on' : 'GIF off';
+
     if (config.picture_timestamp_source) {
       const isSub = config.picture_timestamp_source === 'subtitle_start';
-      timeToggle.textContent = isSub ? 'SUB START' : 'CUR POS';
+      timeToggle.classList.toggle('time-current', !isSub);
+      timeToggle.setAttribute('aria-label', isSub ? 'Subtitle start' : 'Current position');
+      timeToggle.title = isSub ? 'Subtitle start' : 'Current position';
     }
     if (config.history_accent_color) {
       const color = config.history_accent_color.trim();
@@ -259,30 +240,20 @@ ipcRenderer.on('show-history', () => {
 
 ipcRenderer.on('hide-history', () => {
   document.body.classList.remove('visible');
-  setMenuOpen(false);
 });
 
 animToggle.addEventListener('click', () => {
-  setMenuOpen(false);
   ipcRenderer.send('history-toggle-anim');
 });
 
 timeToggle.addEventListener('click', () => {
-  setMenuOpen(false);
   ipcRenderer.send('history-toggle-time-source');
 });
 
 settingsBtn.addEventListener('click', () => {
-  setMenuOpen(false);
   ipcRenderer.send('open-settings');
 });
 
-menuToggle.addEventListener('click', (e) => {
-  e.stopPropagation();
-  setMenuOpen(!isMenuOpen);
-});
-
 clearBtn.addEventListener('click', () => {
-  setMenuOpen(false);
   ipcRenderer.send('history-clear');
 });

--- a/scripts/yomipv/lookup-app/main.js
+++ b/scripts/yomipv/lookup-app/main.js
@@ -663,7 +663,14 @@ ipcMain.on('dictionary-selected', (event, content) => {
 
 ipcMain.on('active-entry', (event, data) => {
   if (data) {
-    sendMpvMessage('script-message', 'yomipv-active-entry', data.expression || '', data.reading || '');
+    sendMpvMessage(
+      'script-message',
+      'yomipv-active-entry',
+      data.expression || '',
+      data.reading || '',
+      String(data.originalLength || 0),
+      String(data.lookupRequestId || 0)
+    );
   }
 });
 

--- a/scripts/yomipv/lookup-app/package.json
+++ b/scripts/yomipv/lookup-app/package.json
@@ -34,14 +34,13 @@
       }
     ],
     "win": {
-      "target": "portable",
+      "target": "dir",
       "icon": "build/lookup-app.png",
       "artifactName": "${productName}.${ext}"
     },
     "linux": {
-      "target": [
-        "AppImage"
-      ],
+      "target": "dir",
+      "executableName": "YomipvLookup",
       "icon": "build/lookup-app.png",
       "artifactName": "${productName}.${ext}"
     },

--- a/scripts/yomipv/lookup-app/renderer.js
+++ b/scripts/yomipv/lookup-app/renderer.js
@@ -55,6 +55,7 @@ let currentAbortController = null;
 let currentPrioritizeKanjiMatch = false;
 let currentPrioritizeHiraganaMatch = false;
 let currentShowPitchAccents = true;
+let currentLookupRequestId = 0;
 
 const renderHeader = (term, reading, frequencies) => {
   const cleanTerm = (term || '').trim();
@@ -189,7 +190,7 @@ const buildFrequencies = (entries, targetExpression, targetReading, showFrequenc
   return Array.from(allFrequenciesMap.values());
 };
 
-const renderEntry = (index, rawEntries, showFrequencies, showPitchAccents) => {
+const renderEntry = (index, rawEntries, showFrequencies, showPitchAccents, lookupRequestId = currentLookupRequestId) => {
   const entry = rawEntries[index];
   if (!entry) return;
 
@@ -303,8 +304,13 @@ const renderEntry = (index, rawEntries, showFrequencies, showPitchAccents) => {
   entryNext.style.display = showNav ? 'flex' : 'none';
   entryCounter.style.display = showNav ? '' : 'none';
   
-  // Sync active entry for Anki export matching
-  ipcRenderer.send('active-entry', { expression: fields.expression, reading: fields.reading });
+  // Sync active entry for Anki export matching and selector expansion.
+  ipcRenderer.send('active-entry', {
+    expression: fields.expression,
+    reading: fields.reading,
+    originalLength: fields._matchedOriginalLength || 0,
+    lookupRequestId
+  });
 };
 
 const sendSelectedDict = (el) => {
@@ -358,8 +364,9 @@ const sendSelectedDict = (el) => {
   ipcRenderer.send('dictionary-selected', dictContent);
 };
 
-const performLookup = async (term, showFrequencies, showPitchAccents, isBack = false, prioritizeKanjiMatch, prioritizeHiraganaMatch) => {
+const performLookup = async (term, showFrequencies, showPitchAccents, isBack = false, prioritizeKanjiMatch, prioritizeHiraganaMatch, lookupRequestId = currentLookupRequestId) => {
   console.log('[UI] Performing lookup for:', term);
+  lookupRequestId = Number(lookupRequestId || 0);
   
   clearSelection();
 
@@ -470,6 +477,7 @@ const performLookup = async (term, showFrequencies, showPitchAccents, isBack = f
     }
 
     if (!result) throw new Error('All Yomitan endpoints failed');
+    if (lookupRequestId !== currentLookupRequestId) return;
 
     currentDictionaryMedia = result.dictionaryMedia || (result[0] && result[0].dictionaryMedia) || [];
     const entries = (result && result.fields) || (result && result[0] && result[0].fields) || [];
@@ -531,6 +539,7 @@ const performLookup = async (term, showFrequencies, showPitchAccents, isBack = f
         }
       }
     } catch (_) { /* Fall back to prefix-match sort */ }
+    if (lookupRequestId !== currentLookupRequestId) return;
 
     const isHiraganaOnly = /^[\u3041-\u309F]+$/.test(term);
     const termChars = toNormalizedChars(term);
@@ -602,9 +611,19 @@ const performLookup = async (term, showFrequencies, showPitchAccents, isBack = f
       }
     });
 
+    for (const entry of sorted) {
+      const fields = entry.fields || entry;
+      const origLen = getOrigLen(fields);
+      if (origLen > 0) {
+        fields._matchedOriginalLength = origLen;
+      } else {
+        delete fields._matchedOriginalLength;
+      }
+    }
+
     allEntries = sorted;
     currentEntryIndex = 0;
-    renderEntry(currentEntryIndex, allEntries, currentShowFrequencies, currentShowPitchAccents);
+    renderEntry(currentEntryIndex, allEntries, currentShowFrequencies, currentShowPitchAccents, lookupRequestId);
 
     if (signal.aborted) return;
 
@@ -661,6 +680,7 @@ const performLookup = async (term, showFrequencies, showPitchAccents, isBack = f
 
 ipcRenderer.on('lookup-term', async (event, data) => {
   console.log('[IPC] Received lookup data:', JSON.stringify(data));
+  currentLookupRequestId = Number(data.lookupRequestId || 0);
   
   if (data.theme === 'light') {
     document.body.classList.add('light-theme');
@@ -689,7 +709,15 @@ ipcRenderer.on('lookup-term', async (event, data) => {
   }
 
   lookupHistory = [];
-  performLookup(data.term, data.showFrequencies, data.showPitchAccents, false, data.prioritizeKanjiMatch, data.prioritizeHiraganaMatch);
+  performLookup(
+    data.term,
+    data.showFrequencies,
+    data.showPitchAccents,
+    false,
+    data.prioritizeKanjiMatch,
+    data.prioritizeHiraganaMatch,
+    currentLookupRequestId
+  );
 });
 
 const handleCopy = () => {

--- a/scripts/yomipv/lookup-app/renderer.js
+++ b/scripts/yomipv/lookup-app/renderer.js
@@ -304,7 +304,7 @@ const renderEntry = (index, rawEntries, showFrequencies, showPitchAccents, looku
   entryNext.style.display = showNav ? 'flex' : 'none';
   entryCounter.style.display = showNav ? '' : 'none';
   
-  // Sync active entry for Anki export matching and selector expansion.
+  // Sync active entry for Anki export matching and selector expansion
   ipcRenderer.send('active-entry', {
     expression: fields.expression,
     reading: fields.reading,

--- a/scripts/yomipv/lookup-app/settings.js
+++ b/scripts/yomipv/lookup-app/settings.js
@@ -46,7 +46,18 @@ const fieldConfigs = {
     { type: 'header', label: 'AnkiConnect' },
     { key: 'ankiconnect_url', label: 'AnkiConnect URL', type: 'text' },
     { key: 'ankiconnect_api_key', label: 'API Key', type: 'password' },
-    { key: 'ankidb_fields', label: 'Anki DB build settings', type: 'text' },
+    {
+      key: 'ankidb_word_fields',
+      label: 'Anki DB Word Fields',
+      type: 'text',
+      desc: 'Separate field names with spaces. Quote field names that contain spaces'
+    },
+    {
+      key: 'ankidb_reading_fields',
+      label: 'Anki DB Reading Fields',
+      type: 'text',
+      desc: 'Separate field names with spaces. Quote field names that contain spaces'
+    },
     { key: 'update_if_exists', label: 'Update if exists', type: 'checkbox', desc: 'Append media if card already exists' },
     { key: 'refresh_gui_after_update', label: 'Refresh Anki GUI', type: 'checkbox', desc: 'Reload Anki browser after export' },
 

--- a/scripts/yomipv/main.lua
+++ b/scripts/yomipv/main.lua
@@ -118,7 +118,7 @@ mp.observe_property("focused", "bool", function(_, is_focused)
 	Curl.post("http://127.0.0.1:19634/app-focus?state=" .. tostring(is_focused), "{}", function() end)
 end)
 
-mp.add_hook("on_pre_shutdown", 50, function()
+mp.register_event("shutdown", function()
 	Launcher.shutdown_lookup_app()
 end)
 
@@ -173,11 +173,13 @@ mp.register_script_message("yomipv-list-profiles", function()
 end)
 
 -- Process selection events and coordinate dictionary expansion
-mp.register_script_message("yomipv-active-entry", function(exp, red)
+mp.register_script_message("yomipv-active-entry", function(exp, red, original_len, lookup_request_id)
 	if not handler then return end
-	handler:set_active_entry(exp, red)
+	if not handler:is_current_lookup_request(lookup_request_id) then return end
+	local matched_len = tonumber(original_len) or 0
+	handler:set_active_entry(exp, red, matched_len)
 	if handler.deps.selector and handler.deps.selector.active then
-		handler.deps.selector:expand_selection_to_match(exp, red)
+		handler.deps.selector:expand_selection_to_match(exp, red, matched_len)
 	end
 end)
 

--- a/scripts/yomipv/media/audio.lua
+++ b/scripts/yomipv/media/audio.lua
@@ -27,8 +27,8 @@ function Audio.create_job(subtitle)
 		return nil
 	end
 
-	local offset = Audio.config.audio_offset or 0
-	local end_offset = Audio.config.audio_end_offset or 0
+	local offset = (not subtitle.is_manual_range) and (Audio.config.audio_offset or 0) or 0
+	local end_offset = (not subtitle.is_manual_range) and (Audio.config.audio_end_offset or 0) or 0
 	local start_time = math.max(0, (subtitle.start or 0) + offset)
 	local end_time = (subtitle["end"] or 0) + end_offset
 

--- a/scripts/yomipv/media/picture.lua
+++ b/scripts/yomipv/media/picture.lua
@@ -30,10 +30,12 @@ function Picture.create_job(subtitle)
 	if Picture.config.picture_animated then
 		local offset = (not subtitle.is_manual_range) and (Picture.config.animation_offset or 0) or 0
 		local end_offset = (not subtitle.is_manual_range) and (Picture.config.animation_end_offset or 0) or 0
-		timestamp = (subtitle.start or 0) + offset + 0.1
+		local subtitle_start = subtitle.start or 0
+		local subtitle_end = subtitle["end"] or subtitle_start
+		timestamp = subtitle_start + offset + 0.1
 
 		if Picture.config.animation_duration == "auto" and subtitle.start and subtitle["end"] then
-			duration = math.max(0.1, subtitle["end"] - subtitle.start + end_offset - offset)
+			duration = math.max(0.1, (subtitle_end + end_offset) - timestamp)
 		else
 			duration = tonumber(Picture.config.animation_duration) or 2.0
 		end

--- a/scripts/yomipv/media/picture.lua
+++ b/scripts/yomipv/media/picture.lua
@@ -28,8 +28,8 @@ function Picture.create_job(subtitle)
 
 	local timestamp, duration
 	if Picture.config.picture_animated then
-		local offset = Picture.config.animation_offset or 0
-		local end_offset = Picture.config.animation_end_offset or 0
+		local offset = (not subtitle.is_manual_range) and (Picture.config.animation_offset or 0) or 0
+		local end_offset = (not subtitle.is_manual_range) and (Picture.config.animation_end_offset or 0) or 0
 		timestamp = (subtitle.start or 0) + offset + 0.1
 
 		if Picture.config.animation_duration == "auto" and subtitle.start and subtitle["end"] then
@@ -38,9 +38,9 @@ function Picture.create_job(subtitle)
 			duration = tonumber(Picture.config.animation_duration) or 2.0
 		end
 	else
-		local offset = Picture.config.picture_static_offset or 0
+		local offset = (not subtitle.is_manual_range) and (Picture.config.picture_static_offset or 0) or 0
 		if Picture.config.picture_timestamp_source == "current_position" then
-			timestamp = mp.get_property_number("time-pos", 0)
+			timestamp = subtitle.picture_timestamp or mp.get_property_number("time-pos", 0)
 		else
 			-- Offset by 0.1s to ensure text rendering and avoid previous subtitle bleeding
 			timestamp = (subtitle.start or 0) + offset + 0.1

--- a/scripts/yomipv/options.lua
+++ b/scripts/yomipv/options.lua
@@ -11,7 +11,8 @@ local default_options = {
 	ankiconnect_api_key = "",
 
 	-- Anki DB build settings
-	ankidb_fields = "word Word expression Expression",
+	ankidb_word_fields = "word Word expression Expression",
+	ankidb_reading_fields = "",
 
 	-- Deck and Note type
 	deck = "Senren",

--- a/scripts/yomipv/subtitle/language.lua
+++ b/scripts/yomipv/subtitle/language.lua
@@ -1,0 +1,66 @@
+--[[ Primary subtitle language detection ]]
+
+local mp = require("mp")
+local StringOps = require("lib.string_ops")
+
+local Language = {}
+
+local japanese_langs = {
+	ja = true,
+	jp = true,
+	jpn = true,
+	japanese = true,
+	nihongo = true,
+	["日本語"] = true,
+}
+
+local function normalize_lang(lang)
+	if type(lang) ~= "string" then return nil end
+	local normalized = lang:lower():gsub("[%s_%-]+", "")
+	return normalized ~= "" and normalized or nil
+end
+
+function Language.is_japanese_lang(lang)
+	local normalized = normalize_lang(lang)
+	return normalized ~= nil and japanese_langs[normalized] == true
+end
+
+function Language.get_primary_subtitle_track()
+	if mp.get_property_native then
+		local current_track = mp.get_property_native("current-tracks/sub")
+		if type(current_track) == "table" then
+			return current_track
+		end
+	end
+
+	local sid = mp.get_property_number("sid")
+	if not sid then
+		return nil
+	end
+
+	local tracks = mp.get_property_native and mp.get_property_native("track-list") or nil
+	if type(tracks) ~= "table" then
+		return nil
+	end
+
+	for _, track in ipairs(tracks) do
+		if track.type == "sub" and tonumber(track.id) == sid then
+			return track
+		end
+	end
+
+	return nil
+end
+
+function Language.is_primary_subtitle_japanese(text)
+	local track = Language.get_primary_subtitle_track()
+	local lang = track and track.lang
+
+	if type(lang) == "string" and lang ~= "" then
+		return Language.is_japanese_lang(lang)
+	end
+
+	return StringOps.has_japanese(text or mp.get_property("sub-text", ""))
+end
+
+return Language

--- a/scripts/yomipv/subtitle/language.lua
+++ b/scripts/yomipv/subtitle/language.lua
@@ -10,7 +10,6 @@ local japanese_langs = {
 	jp = true,
 	jpn = true,
 	japanese = true,
-	nihongo = true,
 	["日本語"] = true,
 }
 

--- a/scripts/yomipv/subtitle/observer.lua
+++ b/scripts/yomipv/subtitle/observer.lua
@@ -4,6 +4,7 @@
 local mp = require("mp")
 local msg = require("mp.msg")
 local Prefetcher = require("subtitle.prefetcher")
+local SubtitleLanguage = require("subtitle.language")
 
 local Observer = {
 	monitor = nil,
@@ -40,9 +41,20 @@ function Observer.handle_subtitle_change(name, value, is_proactive)
 	local StringOps = require("lib.string_ops")
 	local cleaned = StringOps.clean_subtitle(text, true)
 
-	-- Limit colorizer path to primary sub-text or proactive pre-render
-	local is_colorizer_path = (is_proactive or name == "sub-text")
+	-- Limit colorizer path to Japanese primary subtitles
+	local colorizer_candidate = (is_proactive or name == "sub-text")
 		and Observer.config and Observer.config.colorizer_enabled and Observer.yomitan
+	local is_colorizer_path = colorizer_candidate
+		and SubtitleLanguage.is_primary_subtitle_japanese(cleaned)
+	if colorizer_candidate and not is_colorizer_path then
+		if Observer._last_handled_text and Observer._last_handled_text ~= "" then
+			Observer._last_handled_text = ""
+			if Observer.handler and Observer.handler.clear_passive then
+				Observer.handler:clear_passive()
+			end
+		end
+		mp.set_property("sub-visibility", "yes")
+	end
 	if is_colorizer_path then
 		if Observer._last_handled_text ~= cleaned then
 			Observer._last_handled_text = cleaned
@@ -154,6 +166,15 @@ function Observer.handle_time_pos(_, time_pos)
 
 	local StringOps = require("lib.string_ops")
 	local cleaned = StringOps.clean_subtitle(active_text, true)
+	if cleaned ~= "" and not SubtitleLanguage.is_primary_subtitle_japanese(cleaned) then
+		if Observer._last_handled_text and Observer._last_handled_text ~= "" then
+			Observer._last_handled_text = ""
+			if Observer.handler and Observer.handler.clear_passive then
+				Observer.handler:clear_passive()
+			end
+		end
+		return
+	end
 
 	-- Restrict proactive triggers to visible subtitles
 	if cleaned == "" then

--- a/scripts/yomipv/subtitle/observer.lua
+++ b/scripts/yomipv/subtitle/observer.lua
@@ -11,6 +11,8 @@ local Observer = {
 	active = false,
 }
 
+local COLORIZER_LOOKAHEAD_FRAMES = 1.07
+
 -- Initialize subtitle observer state
 function Observer.init(handler, yomitan, config)
 	Observer.handler = handler
@@ -153,12 +155,15 @@ function Observer.handle_time_pos(_, time_pos)
 	if fps <= 0 then fps = 24 end
 	local frame_duration = 1.0 / fps
 
-	-- Look ahead 1 frame to offset OSD render latency
-	local lookahead_time = time_pos + frame_duration
+	-- Look ahead far enough for the OSD update to land on the subtitle frame
+	local lookahead_time = time_pos + (frame_duration * COLORIZER_LOOKAHEAD_FRAMES)
+	local timing_epsilon = 0.001
 
 	local active_text = ""
 	for _, entry in ipairs(Prefetcher._entries) do
-		if lookahead_time >= (entry.start_s + sub_delay) and time_pos <= (entry.end_s + sub_delay) then
+		local start_time = entry.start_s + sub_delay
+		local end_time = entry.end_s + sub_delay
+		if (lookahead_time + timing_epsilon) >= start_time and time_pos <= end_time then
 			active_text = entry.text
 			break
 		end

--- a/scripts/yomipv/subtitle/observer.lua
+++ b/scripts/yomipv/subtitle/observer.lua
@@ -156,8 +156,16 @@ function Observer.handle_time_pos(_, time_pos)
 	local cleaned = StringOps.clean_subtitle(active_text, true)
 
 	-- Restrict proactive triggers to visible subtitles
-	-- Defer clearing to native sub-text observer to respect mpv sub-fix-timing extensions
-	if cleaned ~= "" and Observer._last_handled_text ~= cleaned then
+	if cleaned == "" then
+		local current = mp.get_property("sub-text", "")
+		local current_cleaned = StringOps.clean_subtitle(current, true)
+		if current_cleaned == "" and Observer._last_handled_text and Observer._last_handled_text ~= "" then
+			Observer._last_handled_text = ""
+			if Observer.handler and Observer.handler.clear_passive then
+				Observer.handler:clear_passive()
+			end
+		end
+	elseif Observer._last_handled_text ~= cleaned then
 		Observer.handle_subtitle_change("proactive", active_text, true)
 	end
 end

--- a/scripts/yomipv/subtitle/primary-sid.lua
+++ b/scripts/yomipv/subtitle/primary-sid.lua
@@ -66,8 +66,8 @@ function PrimarySid.auto_load_external_subtitles()
 	end
 
 	if #found_matches > 0 then
-		-- We use cached to avoid immediate overriding if multiple are appended
-		-- Then we check track-list to select the best one.
+		-- Cache entries first to prevent immediate overrides when multiple entries are appended
+		-- Then check the track list and select the best match
 		for _, sub_path in ipairs(found_matches) do
 			msg.info("Auto-loading external subtitle: " .. sub_path)
 			mp.commandv("sub-add", sub_path, "cached")

--- a/scripts/yomipv/subtitle/secondary-sid.lua
+++ b/scripts/yomipv/subtitle/secondary-sid.lua
@@ -171,10 +171,11 @@ function SecondarySid.cycle_track(direction)
 
 	local sub_tracks = {}
 	local current_index = 0
+	local current_sid = mp.get_property_number("sid") or 0
 	local secondary_sid = tonumber(mp.get_property("secondary-sid"))
 
 	for _, track in ipairs(tracks) do
-		if track.type == "sub" then
+		if track.type == "sub" and track.id ~= current_sid then
 			table.insert(sub_tracks, track)
 			if secondary_sid and track.id == secondary_sid then
 				current_index = #sub_tracks
@@ -183,7 +184,7 @@ function SecondarySid.cycle_track(direction)
 	end
 
 	if #sub_tracks == 0 then
-		msg.warn("No subtitle tracks available to cycle")
+		msg.warn("No secondary subtitle tracks available to cycle")
 		return
 	end
 
@@ -198,8 +199,8 @@ function SecondarySid.cycle_track(direction)
 	else
 		if new_index > #sub_tracks then
 			new_index = 0
-		elseif new_index < 0 then
-			new_index = #sub_tracks
+		elseif new_index < 1 then
+			new_index = 0
 		end
 	end
 


### PR DESCRIPTION
A lot of improvements were made to the colorizer for more accurate matching with the actual words in the database and less guessing. Most of the other updates are small fixes and changes. The lookup app is now bundled so it starts faster; previously it was portable, but it is now unpacked on both Windows and Linux.

- Improve Anki DB/colorizer matching:
  - Support reading-based matches from configured Anki reading fields
  - Colorize kana DB entries against kanji subtitle text inside wider tokens
  - Respect `colorizer_ignore_kana_only` without accidentally matching kana readings for kanji-only DB entries
  - Keep adjacent same-color terms separated
  - Clear passive colorizer UI when subtitles disappear
  - Only activate the colorizer on Japanese primary subtitles

- Improve subtitle behavior:
  - Add primary subtitle language detection
  - Make secondary subtitle cycling wrap through `disabled` back to the first track
  - Tune colorizer OSD timing to better match mpv subtitle display

- Improve export/media behavior:
  - Preserve raw subtitle history for manual ranges
  - Use selected capture timestamps correctly
  - Avoid applying subtitle offsets to manual ranges
  - Prevent animated captures from exceeding the selected/manual end time

- Improve AniList matching:
  - Handle filenames with `EPISODE` labels
  - Avoid misreading resolution tags as season/episode data
  - Add fallback matching for dual-title filenames

- Improve lookup app/release packaging:
  - Package unpacked lookup app bundles for faster startup
  - Update launcher/platform handling for unpacked lookup app paths
  - Ignore local lookup app install/build output

- Improve history UI:
  - Replace the history dropdown with compact header icon buttons for GIF mode, timestamp source, clear history, and settings

- Docs/config:
  - Document colorizer reading-field options and Japanese subtitle requirement